### PR TITLE
Use the standard lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# Python HCL2
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/dbdef52c39fb47c896aa1d7876a3a965)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=amplify-education/python-hcl2&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/dbdef52c39fb47c896aa1d7876a3a965)](https://www.codacy.com?utm_source=github.com&utm_medium=referral&utm_content=amplify-education/python-hcl2&utm_campaign=Badge_Coverage)
 [![Build Status](https://travis-ci.org/amplify-education/python-hcl2.svg?branch=master)](https://travis-ci.org/amplify-education/python-hcl2)
@@ -6,6 +5,8 @@
 [![PyPI](https://img.shields.io/pypi/v/python-hcl2.svg)](https://pypi.org/project/python-hcl2/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/python-hcl2.svg)](https://pypi.python.org/pypi/python-hcl2)
 [![Downloads](https://img.shields.io/badge/dynamic/json.svg?label=downloads&url=https%3A%2F%2Fpypistats.org%2Fapi%2Fpackages%2Fpython-hcl2%2Frecent&query=data.last_month&colorB=brightgreen&suffix=%2FMonth)](https://pypistats.org/packages/python-hcl2)
+
+# Python HCL2
 
 A parser for [HCL2](https://github.com/hashicorp/hcl2/blob/master/hcl/spec.md) written in Python using 
 [Lark](https://github.com/lark-parser/lark). This parser only supports HCL2 and isn't backwards compatible

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,13 +1,12 @@
 start : new_line_or_comment? body new_line_or_comment?
 body : (attribute | block | one_line_block)*
-attribute : (identifier | string_lit) "=" expression new_line_or_comment
-block : identifier (identifier | string_lit)* "{" new_line_or_comment body "}" new_line_or_comment?
-one_line_block : identifier (identifier | string_lit)* "{" (identifier "=" expression)? "}" new_line_or_comment
-new_line : /[\n]+/
-new_line_and_or_comma: new_line_or_comment | new_line_or_comment "," | "," | "," new_line_or_comment
-new_line_or_comment: (new_line | /#.*\n/ | /\/\/.*\n/ )+
+attribute : IDENTIFIER "=" expression new_line_or_comment
+block : IDENTIFIER (IDENTIFIER | STRING_LIT)* "{" new_line_or_comment body "}" new_line_or_comment
+one_line_block : IDENTIFIER (IDENTIFIER | STRING_LIT)* "{" (IDENTIFIER "=" expression)? "}" new_line_or_comment
+new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
+new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
 
-identifier : /[a-zA-Z][a-zA-Z0-9_-]*/
+IDENTIFIER : /[a-zA-Z][a-zA-Z0-9_-]*/
 
 ?expression : expr_term | operation | conditional
 
@@ -16,7 +15,7 @@ conditional : expression "?" expression ":" expression
 ?operation : unary_op | binary_op
 !unary_op : ("-" | "!") expr_term
 binary_op : expression binary_term
-!binary_operator : "==" | "!" | "!=" | "<" | ">" | "<=" | ">=" | "-" | "*" | "/" | "%" | "&&" | "||" | "+"
+!binary_operator : "==" | "!=" | "<" | ">" | "<=" | ">=" | "-" | "*" | "/" | "%" | "&&" | "||" | "+"
 binary_term : binary_operator expression
 
 expr_term : "(" expression ")"
@@ -25,38 +24,38 @@ expr_term : "(" expression ")"
             | null_lit
             | float_lit
             | int_lit
-            | string_lit
+            | STRING_LIT
             | tuple
             | object
             | function_call
             | index_expr_term
             | get_attr_expr_term
-            | identifier
+            | IDENTIFIER
             | heredoc_template
             | attr_splat_expr_term
             | full_splat_expr_term
 
 
-!string_lit : "\"" (string_chars | interpolation)* "\""
-?string_chars : /(?:(?!\${)([^"\\]|\\.))+/+
-interpolation : "${" /[^}]+/ "}"
+STRING_LIT : "\"" (STRING_CHARS | INTERPOLATION)* "\""
+STRING_CHARS : /(?:(?!\${)([^"\\]|\\.))+/+ // any character except '"" unless inside a interpolation string
+INTERPOLATION : "${" /[^}]+/ "}"
 
 true_lit : "true"
 false_lit : "false"
 null_lit : "null"
-!int_lit : decimal+
-!float_lit: decimal+ "." decimal+ (exp_mark decimal+)?
-            | decimal+ ("." decimal+)? exp_mark decimal+
-?decimal : "0".."9"
-?exp_mark : ("e" | "E") ("+" | "-")
+int_lit : DECIMAL+
+!float_lit: DECIMAL+ "." DECIMAL+ (EXP_MARK DECIMAL+)?
+            | DECIMAL+ ("." DECIMAL+)? EXP_MARK DECIMAL+
+DECIMAL : "0".."9"
+EXP_MARK : ("e" | "E") ("+" | "-")?
 
 tuple : "[" (new_line_or_comment? expression (new_line_or_comment? "," new_line_or_comment? expression)* new_line_or_comment? ","?)? new_line_or_comment? "]"
 object : "{" (new_line_or_comment? object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
-object_elem : (identifier | expression) "="? expression
+object_elem : (IDENTIFIER | expression) "="? expression
 
 heredoc_template : /<<(?P<name>[a-zA-Z][a-zA-Z0-9-._]+)\n(?:.|\n)+?\n+\s*(?P=name)/
 
-function_call : identifier "(" new_line_or_comment? arguments? new_line_or_comment? ")"
+function_call : IDENTIFIER "(" new_line_or_comment? arguments? new_line_or_comment? ")"
 arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expression)* ("," | "...")? new_line_or_comment?)
 
 index_expr_term : expr_term index
@@ -64,7 +63,7 @@ get_attr_expr_term : expr_term get_attr
 attr_splat_expr_term : expr_term attr_splat
 full_splat_expr_term : expr_term full_splat
 ?index : "[" expression "]"
-?get_attr : "." identifier
+?get_attr : "." IDENTIFIER
 ?attr_splat : ".*" get_attr*
 ?full_splat : "[" "*" "]" (get_attr | index)*
 

--- a/hcl2/parser.py
+++ b/hcl2/parser.py
@@ -40,7 +40,7 @@ def create_parser_file():
     """
     lark_file = os.path.join(dirname(__file__), 'hcl2.lark')
     with open(lark_file, 'r') as lark_file, open(PARSER_FILE, 'w') as parser_file:
-        lark_inst = Lark(lark_file.read(), parser="lalr", lexer="contextual")
+        lark_inst = Lark(lark_file.read(), parser="lalr", lexer="standard")
 
         data, memo = lark_inst.memo_serialize([TerminalDef, Rule])
 

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -24,15 +24,6 @@ class DictTransformer(Transformer):
     def null_lit(self, args: List) -> None:
         return None
 
-    def identifier(self, args: List) -> str:
-        return str(args[0])
-
-    def variable_expr(self, args: List) -> str:
-        return str(args[0])
-
-    def string_lit(self, args: List) -> str:
-        return "".join([str(arg) for arg in args])
-
     def expr_term(self, args: List) -> Any:
         # if the expression starts with a paren then unwrap it
         if args[0] == "(":
@@ -82,9 +73,6 @@ class DictTransformer(Transformer):
     def new_line_and_or_comma(self, args: List) -> Discard:
         return Discard()
 
-    def new_line(self, args: List) -> Discard:
-        return Discard()
-
     def block(self, args: List) -> Dict:
         args = self.strip_new_line_tokens(args)
 
@@ -116,9 +104,6 @@ class DictTransformer(Transformer):
         return {
             key: value
         }
-
-    def interpolation(self, args: List) -> str:
-        return "${%s}" % str(args[0])
 
     def conditional(self, args: List) -> str:
         return "%s ? %s : %s" % (args[0], args[1], args[2])

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __git_hash__ = "GIT_HASH"

--- a/test/helpers/terraform-config/cloudwatch.tf
+++ b/test/helpers/terraform-config/cloudwatch.tf
@@ -5,7 +5,8 @@ resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule" {
   "foo": "bar"
 }
 EOF
-}resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
+}
+resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
   name          = "name"
   event_pattern = jsonencode(var.cloudwatch_pattern_deploytool)
 }


### PR DESCRIPTION
The contextual lexer is throwing errors intermittently. Switching
to the standard lexer fixes this but started raising other grammar
errors. Cleaning up the grammar and changing some rules to be terminals
fixes the standard lexer errors and allows us to use the standard lexer.

Also fixed some places where the grammar was not following the hcl2
spec.