### PR TITLE
Underscore is a valid first character for identifiers

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -6,7 +6,7 @@ one_line_block : IDENTIFIER (IDENTIFIER | STRING_LIT)* "{" (IDENTIFIER "=" expre
 new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
 new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
 
-IDENTIFIER : /[a-zA-Z][a-zA-Z0-9_-]*/
+IDENTIFIER : /[a-zA-Z_][a-zA-Z0-9_-]*/
 
 ?expression : expr_term | operation | conditional
 

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
In HashiCorp's reference implementation, underscore is a valid first character for identifiers:

```
Ident = (ID_Start | '_') (ID_Continue | '-')*;
```

See https://github.com/hashicorp/hcl2/blob/master/hcl/hclsyntax/scan_tokens.rl#L44