### PR TITLE
Handle underscores and dashes in Heredocs

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -32,6 +32,7 @@ expr_term : "(" expression ")"
             | get_attr_expr_term
             | IDENTIFIER
             | heredoc_template
+            | heredoc_template_trim
             | attr_splat_expr_term
             | full_splat_expr_term
             | for_tuple_expr
@@ -55,7 +56,8 @@ tuple : "[" (new_line_or_comment? expression (new_line_or_comment? "," new_line_
 object : "{" (new_line_or_comment? object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
 object_elem : (IDENTIFIER | expression) "="? expression
 
-heredoc_template : /<<(?P<name>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=name)/
+heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc)/
+heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=heredoc_trim)/
 
 function_call : IDENTIFIER "(" new_line_or_comment? arguments? new_line_or_comment? ")"
 arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expression)* ("," | "...")? new_line_or_comment?)

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -55,7 +55,7 @@ tuple : "[" (new_line_or_comment? expression (new_line_or_comment? "," new_line_
 object : "{" (new_line_or_comment? object_elem (new_line_and_or_comma object_elem )* new_line_and_or_comma?)? "}"
 object_elem : (IDENTIFIER | expression) "="? expression
 
-heredoc_template : /<<(?P<name>[a-zA-Z][a-zA-Z0-9-._]+)\n(?:.|\n)+?\n+\s*(?P=name)/
+heredoc_template : /<<(?P<name>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)+?\n+\s*(?P=name)/
 
 function_call : IDENTIFIER "(" new_line_or_comment? arguments? new_line_or_comment? ")"
 arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expression)* ("," | "...")? new_line_or_comment?)

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -4,7 +4,7 @@ from typing import List, Dict, Any
 
 from lark import Transformer, Discard
 
-HEREDOC_PATTERN = re.compile(r'<<([a-zA-Z0-9]+)\n((.|\n)*?)\n\s*\1', re.S)
+HEREDOC_PATTERN = re.compile(r'<<([a-zA-Z][a-zA-Z0-9._-]+)\n((.|\n)*?)\n\s*\1', re.S)
 
 
 # pylint: disable=missing-docstring,unused-argument

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 __git_hash__ = "GIT_HASH"

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.1.5"
+__version__ = "0.2.0"
 __git_hash__ = "GIT_HASH"

--- a/test/helpers/terraform-config-json/cloudwatch.json
+++ b/test/helpers/terraform-config-json/cloudwatch.json
@@ -7,6 +7,18 @@
             "name"
           ],
           "event_pattern": [
+            "    {\n      \"foo\": \"bar\"\n    }"
+          ]
+        }
+      }
+    },
+    {
+      "aws_cloudwatch_event_rule": {
+        "aws_cloudwatch_event_rule2": {
+          "name": [
+            "name"
+          ],
+          "event_pattern": [
             "{\n  \"foo\": \"bar\"\n}"
           ]
         }

--- a/test/helpers/terraform-config/cloudwatch.tf
+++ b/test/helpers/terraform-config/cloudwatch.tf
@@ -1,10 +1,10 @@
 resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule" {
   name = "name"
-  event_pattern = <<EOF
+  event_pattern = <<EOF_CONFIG
 {
   "foo": "bar"
 }
-EOF
+EOF_CONFIG
 }
 resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
   name          = "name"

--- a/test/helpers/terraform-config/cloudwatch.tf
+++ b/test/helpers/terraform-config/cloudwatch.tf
@@ -1,11 +1,21 @@
 resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule" {
   name = "name"
   event_pattern = <<EOF_CONFIG
-{
-  "foo": "bar"
+    {
+      "foo": "bar"
+    }
+      EOF_CONFIG
 }
-EOF_CONFIG
+
+resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
+  name = "name"
+  event_pattern = <<-EOF_CONFIG
+    {
+      "foo": "bar"
+    }
+    EOF_CONFIG
 }
+
 resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
   name          = "name"
   event_pattern = jsonencode(var.cloudwatch_pattern_deploytool)


### PR DESCRIPTION
* Add support for `<<-` type heredocs
* Allow underscores and dashes in heredoc declarations

Closes https://github.com/amplify-education/python-hcl2/issues/7