### PR TITLE
Fix: hcl2tojson dirs tree processing

### DIFF
--- a/bin/hcl2tojson
+++ b/bin/hcl2tojson
@@ -3,7 +3,7 @@
 This script recursively converts hcl2 files to json
 
 Usage:
-    hcl2tojson [-s] PATH OUT_PATH
+    hcl2tojson [-s] PATH [OUT_PATH]
 
 Options:
     -s          Skip un-parsable files
@@ -27,11 +27,17 @@ if __name__ == '__main__':
     in_path = arguments["PATH"]
     out_path = arguments["OUT_PATH"]
     if os.path.isfile(in_path):
-        with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
+        with open(in_path, 'r') as in_file:
+            out_file = sys.stdout if out_path is None else open(out_path, 'w')
             print(in_path, file=sys.stderr, flush=True)
             json.dump(hcl2.parse(in_file.read()), out_file)
+            if out_path is None:
+                out_file.write('\n')
+                out_file.close()
     elif os.path.isdir(in_path):
         processed_files = set()
+        if out_path is None:
+            raise RuntimeError("Positional OUT_PATH parameter shouldn't be empty")
         if not os.path.exists(out_path):
             os.mkdir(out_path)
         for current_dir, dirs, files in os.walk(in_path):

--- a/bin/hcl2tojson
+++ b/bin/hcl2tojson
@@ -10,6 +10,7 @@ Options:
     OUT_PATH    The path to write files to
 """
 import json
+import sys
 import os
 
 from docopt import docopt
@@ -28,10 +29,14 @@ if __name__ == '__main__':
             json.dump(hcl2.parse(in_file.read()), out_file)
     elif os.path.isdir(in_path):
         processed_files = set()
+        if not os.path.exists(out_path):
+            os.mkdir(out_path)
         for current_dir, dirs, files in os.walk(in_path):
             dir_prefix = os.path.commonpath([in_path, current_dir])
-            relative_current_dir = current_dir.replace(dir_prefix, '')
-            current_out_path = os.path.join(out_path, relative_current_dir)
+            relative_current_dir = os.path.relpath(current_dir, dir_prefix)
+            current_out_path = os.path.normpath(os.path.join(out_path, relative_current_dir))
+            if not os.path.exists(current_out_path):
+                os.mkdir(current_out_path)
             for file_name in files:
                 in_file_path = os.path.join(current_dir, file_name)
                 out_file_path = os.path.join(current_out_path, file_name)

--- a/bin/hcl2tojson
+++ b/bin/hcl2tojson
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     out_path = arguments["OUT_PATH"]
     if os.path.isfile(in_path):
         with open(in_path, 'r') as in_file, open(out_path, 'w') as out_file:
-            print(in_path)
+            print(in_path, file=sys.stderr, flush=True)
             json.dump(hcl2.parse(in_file.read()), out_file)
     elif os.path.isdir(in_path):
         processed_files = set()
@@ -45,7 +45,7 @@ if __name__ == '__main__':
                 processed_files.add(out_file_path)
 
                 with open(in_file_path, 'r') as in_file, open(out_file_path, 'w') as out_file:
-                    print(in_file_path)
+                    print(in_file_path, file=sys.stderr, flush=True)
                     json.dump(load(in_file), out_file)
     else:
         raise RuntimeError('Invalid Path %s', in_path)

--- a/bin/hcl2tojson
+++ b/bin/hcl2tojson
@@ -3,9 +3,10 @@
 This script recursively converts hcl2 files to json
 
 Usage:
-    hcl2tojson PATH OUT_PATH
+    hcl2tojson [-s] PATH OUT_PATH
 
 Options:
+    -s          Skip un-parsable files
     PATH        The path to convert
     OUT_PATH    The path to write files to
 """
@@ -18,9 +19,11 @@ from docopt import docopt
 from hcl2 import load
 from hcl2.parser import hcl2
 from hcl2.version import __version__
+from lark import UnexpectedToken
 
 if __name__ == '__main__':
     arguments = docopt(__doc__, version=__version__)
+    skip = arguments["-s"]
     in_path = arguments["PATH"]
     out_path = arguments["OUT_PATH"]
     if os.path.isfile(in_path):
@@ -49,8 +52,15 @@ if __name__ == '__main__':
                 processed_files.add(in_file_path)
                 processed_files.add(out_file_path)
 
-                with open(in_file_path, 'r') as in_file, open(out_file_path, 'w') as out_file:
+                with open(in_file_path, 'r') as in_file:
                     print(in_file_path, file=sys.stderr, flush=True)
-                    json.dump(load(in_file), out_file)
+                    try:
+                        parsed_data = load(in_file)
+                    except UnexpectedToken:
+                        if skip:
+                            continue
+                        raise
+                    with open(out_file_path, 'w') as out_file:
+                        json.dump(parsed_data, out_file)
     else:
         raise RuntimeError('Invalid Path %s', in_path)

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
* Changed filenames printing to stderr by default to don't corrupt json content of writing files.
* Fixed processing of multilevel trees.
* Added skipping of unparsable files. 