### PR TITLE
Add indexed splats into the grammar

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -66,12 +66,12 @@ arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expressi
 index_expr_term : expr_term index
 get_attr_expr_term : expr_term get_attr
 attr_splat_expr_term : expr_term attr_splat
-single_attr_splat_expr_term : expr_term sintle_attr_splat
+single_attr_splat_expr_term : expr_term single_attr_splat
 full_splat_expr_term : expr_term full_splat
 index : "[" new_line_or_comment? expression new_line_or_comment? "]"
 ?get_attr : "." identifier
 ?attr_splat : ".*" get_attr*
-?single_attr_splat : "." DECIMAL* "." get_attr*
+?single_attr_splat : "." DECIMAL* get_attr*
 ?full_splat : "[" "*" "]" (get_attr | index)*
 
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -34,6 +34,7 @@ expr_term : "(" new_line_or_comment? expression new_line_or_comment? ")"
             | heredoc_template
             | heredoc_template_trim
             | attr_splat_expr_term
+            | single_attr_splat_expr_term
             | full_splat_expr_term
             | for_tuple_expr
             | for_object_expr
@@ -65,10 +66,12 @@ arguments : (expression (new_line_or_comment? "," new_line_or_comment?  expressi
 index_expr_term : expr_term index
 get_attr_expr_term : expr_term get_attr
 attr_splat_expr_term : expr_term attr_splat
+single_attr_splat_expr_term : expr_term sintle_attr_splat
 full_splat_expr_term : expr_term full_splat
 index : "[" new_line_or_comment? expression new_line_or_comment? "]"
 ?get_attr : "." identifier
 ?attr_splat : ".*" get_attr*
+?single_attr_splat : "." DECIMAL* "." get_attr*
 ?full_splat : "[" "*" "]" (get_attr | index)*
 
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,4 +1,4 @@
 """Place of record for the package version"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __git_hash__ = "GIT_HASH"


### PR DESCRIPTION
HCL2/Terraform 0.12 make use of a new kind of splat that is formatted like so:

```terraform
type.name.0.identifier
```

Which indexes index 0 of type.name and gets its identifier member. This patch implements parsing this kind of operation.

I have only lightly checked it for bugs, so I would encourage a review.