### PR TITLE
Allow multiline conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[2.0.1] - 2020-12-24
+
+### Changed
+-   Allow multiline conditional statements. Thanks @stpierre ([#51](https://github.com/amplify-education/python-hcl2/pull/51))
+
 ## \[2.0.0] - 2020-11-02
 
 ### Changed

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -9,7 +9,7 @@ identifier : /[a-zA-Z_][a-zA-Z0-9_-]*/
 
 ?expression : expr_term | operation | conditional
 
-conditional : expression "?" expression ":" expression
+conditional : expression "?" new_line_or_comment? expression new_line_or_comment? ":" new_line_or_comment? expression
 
 ?operation : unary_op | binary_op
 !unary_op : ("-" | "!") expr_term

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -114,6 +114,7 @@ class DictTransformer(Transformer):
         }
 
     def conditional(self, args: List) -> str:
+        args = self.strip_new_line_tokens(args)
         return "%s ? %s : %s" % (args[0], args[1], args[2])
 
     def binary_op(self, args: List) -> str:

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,3 +1,3 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/test/helpers/terraform-config/route_table.tf
+++ b/test/helpers/terraform-config/route_table.tf
@@ -1,5 +1,10 @@
 resource "aws_route" "tgw" {
-  count                  = var.tgw_name == "" ? 0 : var.number_of_az
+  count = (
+    var.tgw_name == "" ?
+    0 :
+    var.number_of_az
+  )
+
   route_table_id         = aws_route_table.rt[count.index].id
   destination_cidr_block = "10.0.0.0/8"
   transit_gateway_id     = data.aws_ec2_transit_gateway.tgw[0].id


### PR DESCRIPTION
Terraform allows a ternary to be split among multiple lines, with comments interspersed. For instance:

```
count = (
  var.tgw_name == "" ?  # put a comment here for fun
  0 :
  var.number_of_az
)
```

Previously, the grammar only supported single-line ternary expressions.