### PR TITLE
Handle null objects

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,6 +1,6 @@
 start : new_line_or_comment? body new_line_or_comment?
 body : (attribute | block)*
-attribute : identifier "=" expression (new_line_or_comment)?
+attribute : (identifier | null_lit) "=" expression (new_line_or_comment)?
 block : identifier (identifier | STRING_LIT)* "{" (new_line_or_comment)? body "}" new_line_or_comment
 new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
 new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+


### PR DESCRIPTION
Currently null objects raise an error while being parsed, this change should handle them.
For example:
```terraform {
  required_version = ">= 0.12.26"

  required_providers {
    null = {
      source  = "hashicorp/null"
      version = ">= 2.0"
    }
  }
}```