### PR TITLE
Skip more exceptions for un-parsable files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[2.0.3] - 2021-03-04
+
+### Changed
+-   Skip more exceptions for un-parsable files. Thanks @tanasegabriel ([#60](https://github.com/amplify-education/python-hcl2/pull/60))
+
 ## \[2.0.2] - 2021-03-04
 
 ### Changed

--- a/bin/hcl2tojson
+++ b/bin/hcl2tojson
@@ -18,7 +18,7 @@ import sys
 from hcl2 import load
 from hcl2.parser import hcl2
 from hcl2.version import __version__
-from lark import UnexpectedToken
+from lark import UnexpectedToken, UnexpectedCharacters
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='This script recursively converts hcl2 files to json')
@@ -33,6 +33,13 @@ if __name__ == '__main__':
     parser.add_argument('--version', action='version', version=__version__)
 
     args = parser.parse_args()
+
+    skippable_exceptions = (
+        UnexpectedToken,
+        UnexpectedCharacters,
+        UnicodeDecodeError
+    )
+
     if os.path.isfile(args.PATH):
         with open(args.PATH, 'r') as in_file:
             out_file = sys.stdout if args.OUT_PATH is None else open(args.OUT_PATH, 'w')
@@ -69,7 +76,7 @@ if __name__ == '__main__':
                     print(in_file_path, file=sys.stderr, flush=True)
                     try:
                         parsed_data = load(in_file)
-                    except UnexpectedToken:
+                    except skippable_exceptions:
                         if args.skip:
                             continue
                         raise

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,3 +1,3 @@
 """Place of record for the package version"""
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"


### PR DESCRIPTION
One commonly used pattern is having a Terraform mono-repo. `hcl2tojson` is great for converting a bunch of `.tf` files to `json`, enabling easy parsing on the fly. It can however get tripped by readme files or git files:

```python
./<redacted>/<redacted>/<redacted>/README.md
Traceback (most recent call last):
  File "/usr/local/bin/hcl2tojson", line 71, in <module>
    parsed_data = load(in_file)
  File "/usr/local/lib/python3.9/site-packages/hcl2/api.py", line 9, in load
    return loads(file.read())
  File "/usr/local/lib/python3.9/site-packages/hcl2/api.py", line 18, in loads
    return hcl2.parse(text + "\n")
  File "/usr/local/lib/python3.9/site-packages/lark/lark.py", line 464, in parse
    return self.parser.parse(text, start=start)
  File "/usr/local/lib/python3.9/site-packages/lark/parser_frontends.py", line 115, in parse
    return self._parse(token_stream, start)
  File "/usr/local/lib/python3.9/site-packages/lark/parser_frontends.py", line 63, in _parse
    return self.parser.parse(input, start, *args)
  File "/usr/local/lib/python3.9/site-packages/lark/parsers/lalr_parser.py", line 35, in parse
    return self.parser.parse(*args)
  File "/usr/local/lib/python3.9/site-packages/lark/parsers/lalr_parser.py", line 86, in parse
    for token in stream:
  File "/usr/local/lib/python3.9/site-packages/lark/lexer.py", line 200, in lex
    raise UnexpectedCharacters(stream, line_ctr.char_pos, line_ctr.line, line_ctr.column, allowed=allowed, state=self.state, token_history=last_token and [last_token])
lark.exceptions.UnexpectedCharacters: No terminal defined for '|' at line 6 col 1

| Name | Description | Type | Default |
^

Expecting: {'SLASH', '__ANON_4', 'COLON', '__ANON_10', 'COMMA', '__ANON_9', 'LPAR', 'LSQB', '__ANON_7', '__ANON_8', 'BANG', 'STRING_LIT', 'DECIMAL', 'QMARK', 'RSQB', 'DOT', 'MINUS', '__ANON_11', '__ANON_3', 'LESSTHAN', 'RPAR', 'LBRACE', '__ANON_13', 'PERCENT', 'RBRACE', '__ANON_1', 'STAR', '__ANON_12', 'EQUAL', '__ANON_5', 'PLUS', '__ANON_0', 'MORETHAN', 'heredoc_trim', '__ANON_14', '__ANON_2', '__ANON_6', 'heredoc', 'EXP_MARK'}

Previous tokens: Token('__ANON_0', '\n')
```

```python
./.git/index
Traceback (most recent call last):
  File "/usr/local/bin/hcl2tojson", line 71, in <module>
    parsed_data = load(in_file)
  File "/usr/local/lib/python3.9/site-packages/hcl2/api.py", line 9, in load
    return loads(file.read())
  File "/usr/local/Cellar/python@3.9/3.9.0_5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xfe in position 14: invalid start byte
```

Rescuing more of these commonly encountered exceptions under the `-s` arg (skip) should enable more usage cases.