### PR TITLE
Fix for_object_expr

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -65,7 +65,7 @@ index : "[" new_line_or_comment? expression new_line_or_comment? "]" | "." DECIM
 ?full_splat : "[" "*" "]" (get_attr | index)*
 
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"
-!for_object_expr : "{" new_line_or_comment? for_intro expression "=>" expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
+!for_object_expr : "{" new_line_or_comment? for_intro expression "=>" new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
 !for_intro : "for" new_line_or_comment? identifier ("," identifier new_line_or_comment?)? new_line_or_comment? "in" new_line_or_comment? expression ":" new_line_or_comment?
 !for_cond : "if" new_line_or_comment? expression
 


### PR DESCRIPTION
'for' arrow expr can be followed by a newline before stating the rest

Example that did not work before and does now: https://github.com/cloudposse/terraform-null-label/blob/master/main.tf#L77

I don't think this includes regression. Ran it on a pretty large set of files with success.