### PR TITLE
fix issue of whitespace around for expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## \[3.0.2] - 2022-02-20
+-   Fix issue of whitespace around for expressions. Thanks @ryanking and @matchaxnb ([#87](https://github.com/amplify-education/python-hcl2/pull/87))
+
 ## \[3.0.1] - 2021-07-15
 -   Include the generated parser in distribution
 

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -65,7 +65,7 @@ index : "[" new_line_or_comment? expression new_line_or_comment? "]" | "." DECIM
 ?full_splat : "[" "*" "]" (get_attr | index)*
 
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"
-!for_object_expr : "{" new_line_or_comment? for_intro expression "=>" expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
+!for_object_expr : "{" new_line_or_comment? for_intro new_line_or_comment? expression "=>" new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
 !for_intro : "for" new_line_or_comment? identifier ("," identifier new_line_or_comment?)? new_line_or_comment? "in" new_line_or_comment? expression ":" new_line_or_comment?
 !for_cond : "if" new_line_or_comment? expression
 

--- a/hcl2/version.py
+++ b/hcl2/version.py
@@ -1,3 +1,3 @@
 """Place of record for the package version"""
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -35,7 +35,8 @@
     },
     {
       "route53_forwarding_rule_shares": "${{for forwarding_rule_key in keys(var.route53_resolver_forwarding_rule_shares) : \"${forwarding_rule_key}\" => {'aws_account_ids': '${[for account_name in var.route53_resolver_forwarding_rule_shares[forwarding_rule_key].aws_account_names : module.remote_state_subaccounts.map[account_name].outputs[\"aws_account_id\"]]}'}}}",
-      "has_valid_forwarding_rules_template_inputs": "${length(keys(var.forwarding_rules_template.copy_resolver_rules)) > 0 && length(var.forwarding_rules_template.replace_with_target_ips) > 0 && length(var.forwarding_rules_template.exclude_cidrs) > 0}"
+      "has_valid_forwarding_rules_template_inputs": "${length(keys(var.forwarding_rules_template.copy_resolver_rules)) > 0 && length(var.forwarding_rules_template.replace_with_target_ips) > 0 && length(var.forwarding_rules_template.exclude_cidrs) > 0}",
+      "for_whitespace": "${{for i in [1, 2, 3] : i => i}}"
     }
   ]
 }

--- a/test/helpers/terraform-config/variables.tf
+++ b/test/helpers/terraform-config/variables.tf
@@ -46,4 +46,9 @@ locals {
     length(var.forwarding_rules_template.replace_with_target_ips) > 0 &&
     length(var.forwarding_rules_template.exclude_cidrs) > 0
   )
+
+  for_whitespace = { for i in [1, 2, 3] :
+    i =>
+    i
+  }
 }


### PR DESCRIPTION
I noticed that the parser would error if whitespace was included after
the => in a for expression like the one I added to the tests.
