### PR TITLE
Include space after comma in function parameters

### DIFF
--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -87,7 +87,7 @@ class DictTransformer(Transformer):
         args = self.strip_new_line_tokens(args)
         args_str = ''
         if len(args) > 1:
-            args_str = ",".join([str(arg) for arg in args[1]])
+            args_str = ", ".join([str(arg) for arg in args[1]])
         return "%s(%s)" % (str(args[0]), args_str)
 
     def arguments(self, args: List) -> List:

--- a/test/helpers/terraform-config-json/data_sources.json
+++ b/test/helpers/terraform-config-json/data_sources.json
@@ -3,7 +3,7 @@
     {
       "terraform_remote_state": {
         "map": {
-          "for_each": "${{for s3_bucket_key in data.aws_s3_bucket_objects.remote_state_objects.keys : regex(local.remote_state_regex,s3_bucket_key)[\"account_alias\"] => s3_bucket_key if length(regexall(local.remote_state_regex,s3_bucket_key)) > 0}}",
+          "for_each": "${{for s3_bucket_key in data.aws_s3_bucket_objects.remote_state_objects.keys : regex(local.remote_state_regex, s3_bucket_key)[\"account_alias\"] => s3_bucket_key if length(regexall(local.remote_state_regex, s3_bucket_key)) > 0}}",
           "backend": "s3"
         }
       }

--- a/test/helpers/terraform-config-json/iam.json
+++ b/test/helpers/terraform-config-json/iam.json
@@ -31,7 +31,7 @@
               "actions": [
                 "s3:GetObject"
               ],
-              "resources": "${[for bucket_name in local.buckets_to_proxy : \"arn:aws:s3:::${bucket_name}/*\" if substr(bucket_name,0,1) == \"l\"]}"
+              "resources": "${[for bucket_name in local.buckets_to_proxy : \"arn:aws:s3:::${bucket_name}/*\" if substr(bucket_name, 0, 1) == \"l\"]}"
             }
           ]
         }

--- a/test/helpers/terraform-config-json/locals_embedded_multi_function_nested.json
+++ b/test/helpers/terraform-config-json/locals_embedded_multi_function_nested.json
@@ -1,8 +1,8 @@
 {
   "locals": [
     {
-      "multi_function": "${substr(split(\"-\",\"us-west-2\")[0],0,1)}",
-      "multi_function_embedded": "${substr(split(\"-\",\"us-west-2\")[0],0,1)}"
+      "multi_function": "${substr(split(\"-\", \"us-west-2\")[0], 0, 1)}",
+      "multi_function_embedded": "${substr(split(\"-\", \"us-west-2\")[0], 0, 1)}"
     }
   ]
 }

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -28,14 +28,14 @@
     },
     {
       "var_with_validation": {
-        "type": "${list(object({'id': '${string}', 'nested': \"${list(object({'id': '${string}', 'type': '${string}'}),)}\"}))}",
+        "type": "${list(object({'id': '${string}', 'nested': \"${list(object({'id': '${string}', 'type': '${string}'}), )}\"}))}",
         "validation": [
           {
-            "condition": "${!contains([for v in flatten(var.var_with_validation[*].id) : can(regex(\"^(A|B)$\",v))],False)}",
+            "condition": "${!contains([for v in flatten(var.var_with_validation[*].id) : can(regex(\"^(A|B)$\", v))], False)}",
             "error_message": "The property `id` must be one of value [A, B]."
           },
           {
-            "condition": "${!contains([for v in flatten(var.var_with_validation[*].nested[*].type) : can(regex(\"^(A|B)$\",v))],False)}",
+            "condition": "${!contains([for v in flatten(var.var_with_validation[*].nested[*].type) : can(regex(\"^(A|B)$\", v))], False)}",
             "error_message": "The property `nested.type` must be one of value [A, B]."
           }
         ]


### PR DESCRIPTION
The current parsing of functions is creating `terraform fmt` difficulty when the parsed content is used to generate terraform code.

Example source `test.tf`:
```
locals {
  foo = []
  bar = []
  baz = concat(foo, bar)
}
```

Example code:
```
import hcl2
with open("test.tf", "r") as file:
  tf_dict = hcl2.load(file)

print(tf_dict["locals"][0]["baz"])
```

Before this change, the output is `${concat(foo,bar)}` (Note the lack of space between `foo` and `bar`).
After this change, the output is `${concat(foo, bar)}` (Note the presence of the space).