### PR TITLE
Update lark-parser constraint to allow newer versions.

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,3 +1,3 @@
 # Place dependencies in this file, following the distutils format:
 # http://docs.python.org/2/distutils/setupscript.html#relationships-between-distributions-and-packages
-lark-parser>=0.10.0,<0.11.0
+lark-parser>=0.12.0,<0.13.0


### PR DESCRIPTION
Latest version is 0.12.0, current constraints don't allow this version to be pulled in. 
Unit tests are passing with this version of `lark-parser` (using bare `tox` invocation).
