### PR TITLE
Make provision for block on next line.

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,7 +1,7 @@
 start : body
 body : (new_line_or_comment? (attribute | block))* new_line_or_comment?
 attribute : identifier "=" expression
-block : identifier (identifier | STRING_LIT)* "{" body "}"
+block : identifier (identifier | STRING_LIT)* new_line_or_comment? "{" body "}"
 new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
 new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
 


### PR DESCRIPTION

I think this addresses #97 . It makes it possible for there to be syntax-irrelevant chaff between the title of the block and the definition of the block.

before, 
'''
path "sys/auth" {
  capabilities = ["read"]
}
'''

parsed, but 

'''
path "sys/auth" 
{
  capabilities = ["read"]
}
'''

did not. 

