### PR TITLE
hcl2-lark-grammer-improvements

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -7,7 +7,7 @@ new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
 
 identifier : /[a-zA-Z_][a-zA-Z0-9_-]*/
 
-?expression : expr_term | operation | conditional
+?expression : conditional | expr_term | operation
 
 conditional : expression "?" new_line_or_comment? expression new_line_or_comment? ":" new_line_or_comment? expression new_line_or_comment?
 

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -66,7 +66,7 @@ attr_splat : ".*" get_attr*
 full_splat : "[*]" (get_attr | index)*
 
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"
-!for_object_expr : "{" new_line_or_comment? for_intro new_line_or_comment? expression "=>" new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
+!for_object_expr : "{" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? "=>" new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
 !for_intro : "for" new_line_or_comment? identifier ("," identifier new_line_or_comment?)? new_line_or_comment? "in" new_line_or_comment? expression new_line_or_comment? ":" new_line_or_comment?
 !for_cond : "if" new_line_or_comment? expression
 


### PR DESCRIPTION
The first commit solves the following syntax:
```
compute_instances_by_zone = {
    for i in range(length(google_compute_instance.default.*.self_link)) :
    data.google_compute_zones.available.names[(i + var.zone_to_start_with) % 3]
    => google_compute_instance.default.*.self_link[i]...
}
```

The second one is more of a way to improve the prioritization of expression parsing, putting conditional first makes sense, as it's the most extensive, so it's the least likely to be wrong, which is important with the 'lalr' parser, as it can go only one token back