### PR TITLE
Allow expressions in string interpolation

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -1,7 +1,7 @@
 start : body
 body : (new_line_or_comment? (attribute | block))* new_line_or_comment?
 attribute : identifier "=" expression
-block : identifier (identifier | STRING_LIT)* new_line_or_comment? "{" body "}"
+block : identifier (identifier | string_lit)* new_line_or_comment? "{" body "}"
 new_line_and_or_comma: new_line_or_comment | "," | "," new_line_or_comment
 new_line_or_comment: ( /\n/ | /#.*\n/ | /\/\/.*\n/ )+
 
@@ -20,7 +20,7 @@ binary_term : binary_operator new_line_or_comment? expression
 expr_term : "(" new_line_or_comment? expression new_line_or_comment? ")"
             | float_lit
             | int_lit
-            | STRING_LIT
+            | string_lit
             | tuple
             | object
             | function_call
@@ -35,10 +35,9 @@ expr_term : "(" new_line_or_comment? expression new_line_or_comment? ")"
             | for_object_expr
 
 
-STRING_LIT : "\"" (STRING_CHARS | INTERPOLATION)* "\""
+string_lit : "\"" (STRING_CHARS | interpolation)* "\""
 STRING_CHARS : /(?:(?!\${)([^"\\]|\\.))+/+ // any character except '"" unless inside a interpolation string
-NESTED_INTERPOLATION : "${" /[^}]+/ "}"
-INTERPOLATION : "${" (/(?:(?!\${)([^}]))+/ | NESTED_INTERPOLATION)+ "}"
+interpolation : "${" expression "}"
 
 int_lit : DECIMAL+
 !float_lit: DECIMAL+ "." DECIMAL+ (EXP_MARK DECIMAL+)?

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -41,6 +41,12 @@ class DictTransformer(Transformer):
     def int_lit(self, args: List) -> int:
         return int("".join([str(arg) for arg in args]))
 
+    def string_lit(self, args: List) -> str:
+        return '"' + "".join([str(arg) for arg in args]) + '"'
+
+    def interpolation(self, args: List) -> str:
+        return "".join([self.to_string_dollar(arg) for arg in args])
+
     def expr_term(self, args: List) -> Any:
         args = self.strip_new_line_tokens(args)
 

--- a/test/helpers/terraform-config-json/locals_embedded_nested_interpolation.json
+++ b/test/helpers/terraform-config-json/locals_embedded_nested_interpolation.json
@@ -1,0 +1,7 @@
+{
+  "locals": [
+    {
+      "nested_interpolation": "tags: ${join(\";\", ['names:${join(\",\", [\\'name:${example}\\'])}'])}"
+    }
+  ]
+}

--- a/test/helpers/terraform-config/locals_embedded_multi_function_nested.tf
+++ b/test/helpers/terraform-config/locals_embedded_multi_function_nested.tf
@@ -2,5 +2,5 @@
 # both values should evaluate to the same values
 locals {
   multi_function          = substr(split("-", "us-west-2")[0], 0, 1)
-  multi_function_embedded = substr(split("-", "us-west-2")[0], 0, 1)
+  multi_function_embedded = "${substr(split("-", "us-west-2")[0], 0, 1)}"
 }

--- a/test/helpers/terraform-config/locals_embedded_nested_interpolation.tf
+++ b/test/helpers/terraform-config/locals_embedded_nested_interpolation.tf
@@ -1,0 +1,3 @@
+locals {
+  nested_interpolation = "tags: ${join(";", ["names:${join(",", ["name:${example}"])}"])}"
+}


### PR DESCRIPTION
HCL allows for any expression in a string interpolation. This updates the grammar and transformer to match, allowing for arbitrarily-deep nesting.