### PR TITLE
fix parsing of `null`

### DIFF
--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -343,6 +343,8 @@ class DictTransformer(Transformer):
             return value
         if isinstance(value, int):
             return str(value)
+        if value is None:
+            return "None"
 
         raise RuntimeError(f"Invalid type to convert to inline HCL: {type(value)}")
 

--- a/test/unit/test_hcl2_syntax.py
+++ b/test/unit/test_hcl2_syntax.py
@@ -164,3 +164,11 @@ class TestHcl2Syntax(Hcl2Helper, TestCase):
         for actual, expected in literals.items():
             result = self.load_to_dict(actual)
             self.assertDictEqual(result, expected)
+
+    def test_null(self):
+        identifier = "var = null"
+
+        expected = {"var": None}
+
+        result = self.load_to_dict(identifier)
+        self.assertDictEqual(result, expected)


### PR DESCRIPTION
- fix parsing of `null` literals
- add unit test for the above

this fixes https://github.com/amplify-education/python-hcl2/issues/183