### PR TITLE
DictTransformer - do not wrap type literals into `${` and `}`

### DIFF
--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -30,6 +30,10 @@ class DictTransformer(Transformer):
 
     with_meta: bool
 
+    @staticmethod
+    def is_type_keyword(value: str) -> bool:
+        return value in {"bool", "number", "string"}
+
     def __init__(self, with_meta: bool = False):
         """
         :param with_meta: If set to true then adds `__start_line__` and `__end_line__`
@@ -301,6 +305,10 @@ class DictTransformer(Transformer):
             if value.startswith('"') and value.endswith('"'):
                 value = str(value)[1:-1]
                 return self.process_escape_sequences(value)
+
+            if self.is_type_keyword(value):
+                return value
+
             return f"${{{value}}}"
         return value
 

--- a/test/helpers/terraform-config-json/multiline_expressions.json
+++ b/test/helpers/terraform-config-json/multiline_expressions.json
@@ -42,12 +42,12 @@
     {
       "some_var2": {
         "description": "description",
-        "type": "${string}",
+        "type": "string",
         "default": "${cidrsubnets(\"10.0.0.0/24\", 2, 2)}"
       }
     },
     {
-      "some_var2": {
+      "some_var3": {
         "description": "description",
         "default": "${concat([{\"1\": \"1\"}], [{\"2\": \"2\"}])}"
       }

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -22,13 +22,13 @@
     },
     {
       "options": {
-        "type": "${string}",
+        "type": "string",
         "default": {}
       }
     },
     {
       "var_with_validation": {
-        "type": "${list(object({\"id\": \"${string}\", \"nested\": \"${list(object({\"id\": \"${string}\", \"type\": \"${string}\"}))}\"}))}",
+        "type": "${list(object({\"id\": \"string\", \"nested\": \"${list(object({\"id\": \"string\", \"type\": \"string\"}))}\"}))}",
         "validation": [
           {
             "condition": "${!contains([for v in flatten(var.var_with_validation[*].id) : can(regex(\"^(A|B)$\", v))], false)}",

--- a/test/helpers/terraform-config/multiline_expressions.tf
+++ b/test/helpers/terraform-config/multiline_expressions.tf
@@ -47,7 +47,7 @@ variable "some_var2" {
   )
 }
 
-variable "some_var2" {
+variable "some_var3" {
   description = "description"
   default = concat(
     # comment 1

--- a/test/unit/test_dict_transformer.py
+++ b/test/unit/test_dict_transformer.py
@@ -1,0 +1,32 @@
+# pylint:disable=C0114,C0116,C0103,W0612
+
+from unittest import TestCase
+
+from hcl2.transformer import DictTransformer
+
+
+class TestDictTransformer(TestCase):
+    """Test behaviour of hcl2.transformer.DictTransformer class"""
+
+    @staticmethod
+    def build_dict_transformer(with_meta: bool = False) -> DictTransformer:
+        return DictTransformer(with_meta)
+
+    def test_to_string_dollar(self):
+        string_values = {
+            '"bool"': "bool",
+            '"number"': "number",
+            '"string"': "string",
+            "${value_1}": "${value_1}",
+            '"value_2': '${"value_2}',
+            'value_3"': '${value_3"}',
+            '"value_4"': "value_4",
+            "value_5": "${value_5}",
+        }
+
+        dict_transformer = self.build_dict_transformer()
+
+        for value, expected in string_values.items():
+            actual = dict_transformer.to_string_dollar(value)
+
+            self.assertEqual(actual, expected)


### PR DESCRIPTION
- make an exception for `bool`, `number` and `string` literals to not be wrapped into string dollars
- add unit tests for the above

this fixes #179 