### PR TITLE
heredoc parsing: require ending delimiter to be on its own line with optional indentation

### DIFF
--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -74,8 +74,8 @@ object : "{" new_line_or_comment? (object_elem (new_line_and_or_comma object_ele
 object_elem : (identifier | expression) ( EQ | ":") expression
 
 
-heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)*?(?P=heredoc)/
-heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)*?(?P=heredoc_trim)/
+heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n?(?:.|\n)*?\n\s*(?P=heredoc)\n/
+heredoc_template_trim : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n?(?:.|\n)*?\n\s*(?P=heredoc_trim)\n/
 
 function_call : identifier "(" new_line_or_comment? arguments? new_line_or_comment? ")"
 arguments : (expression (new_line_or_comment* "," new_line_or_comment*  expression)* ("," | "...")? new_line_or_comment*)

--- a/test/helpers/terraform-config-json/cloudwatch.json
+++ b/test/helpers/terraform-config-json/cloudwatch.json
@@ -4,7 +4,7 @@
       "aws_cloudwatch_event_rule": {
         "aws_cloudwatch_event_rule": {
           "name": "name",
-          "event_pattern": "    {\n      \"foo\": \"bar\"\n    }"
+          "event_pattern": "    {\n      \"foo\": \"bar\",\n      \"foo2\": \"EOF_CONFIG\"\n    }"
         }
       }
     },
@@ -12,7 +12,7 @@
       "aws_cloudwatch_event_rule": {
         "aws_cloudwatch_event_rule2": {
           "name": "name",
-          "event_pattern": "{\n  \"foo\": \"bar\"\n}"
+          "event_pattern": "{\n  \"foo\": \"bar\",\n  \"foo2\": \"EOF_CONFIG\"\n}"
         }
       }
     },

--- a/test/helpers/terraform-config/cloudwatch.tf
+++ b/test/helpers/terraform-config/cloudwatch.tf
@@ -2,7 +2,8 @@ resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule" {
   name          = "name"
   event_pattern = <<EOF_CONFIG
     {
-      "foo": "bar"
+      "foo": "bar",
+      "foo2": "EOF_CONFIG"
     }
       EOF_CONFIG
 }
@@ -11,7 +12,8 @@ resource "aws_cloudwatch_event_rule" "aws_cloudwatch_event_rule2" {
   name          = "name"
   event_pattern = <<-EOF_CONFIG
     {
-      "foo": "bar"
+      "foo": "bar",
+      "foo2": "EOF_CONFIG"
     }
     EOF_CONFIG
 }


### PR DESCRIPTION
this fixes #190 