### PR TITLE
allow expression as an object key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## \[Unreleased\]
 
-- Nothing yet
+### Fixed
+
+- Issue parsing inline expression as an object key; **see Limitations in README.md** ([#222](https://github.com/amplify-education/python-hcl2/pull/222))
 
 ## \[7.1.0\] - 2025-04-10
 

--- a/README.md
+++ b/README.md
@@ -104,3 +104,16 @@ We’ll try to answer any PR’s promptly.
     name = "prefix1-${"prefix2-${local.foo_bar}"}" //interpolates into "prefix1-prefix2-foo-bar"
   }
   ```
+
+### Using inline expression as an object key
+
+- Object key can be an expression as long as it is wrapped in parentheses:
+  ```terraform
+    locals {
+      foo = "bar"
+      baz = {
+        (format("key_prefix_%s", local.foo)) : "value"
+        # format("key_prefix_%s", local.foo) : "value" this will fail
+      }
+    }
+  ```

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -75,8 +75,9 @@ EQ : /[ \t]*=(?!=|>)/
 
 tuple : "[" (new_line_or_comment* expression new_line_or_comment* ",")* (new_line_or_comment* expression)? new_line_or_comment* "]"
 object : "{" new_line_or_comment? (new_line_or_comment* (object_elem | (object_elem COMMA)) new_line_or_comment*)* "}"
-object_elem : LPAR? object_elem_key RPAR? ( EQ | COLON ) expression
-object_elem_key : float_lit | int_lit | identifier | STRING_LIT | object_elem_key_dot_accessor
+object_elem : object_elem_key ( EQ | COLON ) expression
+object_elem_key : float_lit | int_lit | identifier | STRING_LIT | object_elem_key_dot_accessor | object_elem_key_expression
+object_elem_key_expression : LPAR expression RPAR
 object_elem_key_dot_accessor : identifier (DOT identifier)+
 
 heredoc_template : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n?(?:.|\n)*?\n\s*(?P=heredoc)\n/
@@ -98,7 +99,7 @@ full_splat : "[*]" (get_attr | index)*
 
 FOR_OBJECT_ARROW : "=>"
 !for_tuple_expr : "[" new_line_or_comment? for_intro new_line_or_comment? expression new_line_or_comment? for_cond? new_line_or_comment? "]"
-!for_object_expr : "{" new_line_or_comment? for_intro new_line_or_comment? expression FOR_OBJECT_ARROW new_line_or_comment? expression "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
+!for_object_expr : "{" new_line_or_comment? for_intro new_line_or_comment? expression FOR_OBJECT_ARROW new_line_or_comment? expression new_line_or_comment? "..."? new_line_or_comment? for_cond? new_line_or_comment? "}"
 !for_intro : "for" new_line_or_comment? identifier ("," identifier new_line_or_comment?)? new_line_or_comment? "in" new_line_or_comment? expression new_line_or_comment? ":" new_line_or_comment?
 !for_cond : "if" new_line_or_comment? expression
 

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -98,20 +98,18 @@ class DictTransformer(Transformer):
     def object_elem(self, args: List) -> Dict:
         # This returns a dict with a single key/value pair to make it easier to merge these
         # into a bigger dict that is returned by the "object" function
-        if args[0] == Token("LPAR", "("):
-            key = self.strip_quotes(str(args[1].children[0]))
-            key = f"({key})"
-            key = self.to_string_dollar(key)
-            value = args[4]
-        else:
-            key = self.strip_quotes(str(args[0].children[0]))
-            value = args[2]
+
+        key = self.strip_quotes(str(args[0].children[0]))
+        value = args[2]
 
         value = self.to_string_dollar(value)
         return {key: value}
 
     def object_elem_key_dot_accessor(self, args: List) -> str:
         return "".join(args)
+
+    def object_elem_key_expression(self, args: List) -> str:
+        return self.to_string_dollar("".join(args))
 
     def object(self, args: List) -> Dict:
         args = self.strip_new_line_tokens(args)

--- a/test/helpers/terraform-config-json/variables.json
+++ b/test/helpers/terraform-config-json/variables.json
@@ -47,7 +47,8 @@
       "foo": "${var.account}_bar",
       "bar": {
         "baz": 1,
-        "${(var.account)}": 2
+        "${(var.account)}": 2,
+        "${(format(\"key_prefix_%s\", local.foo))}": 3
       },
       "tuple": ["${local.foo}"],
       "empty_tuple": []

--- a/test/helpers/terraform-config/variables.tf
+++ b/test/helpers/terraform-config/variables.tf
@@ -9,6 +9,7 @@ locals {
   bar = {
     baz : 1
     (var.account) : 2
+    (format("key_prefix_%s", local.foo)) : 3
   }
   tuple = [local.foo]
   empty_tuple = []


### PR DESCRIPTION
(limitation: expression must be wrapped in parentheses)

related to #219 