### PR TITLE
Add .[] as jq-compatible alias for [*] and document jq interop

### DIFF
--- a/docs/04_hq.md
+++ b/docs/04_hq.md
@@ -44,7 +44,7 @@ type_filter := IDENTIFIER
 - `name` matches block types and attribute names
 - `type:name` matches only nodes of the given type (e.g. `function_call:length`)
 - `name~` skips all block labels, going straight to the body (see below)
-- `[*]` selects all matches at that level
+- `[*]` or `.[]` selects all matches at that level (`.[]` is a jq-compatible alias)
 - `[N]` selects the Nth match (zero-based)
 - `[select(PRED)]` filters matches using a predicate (see below)
 
@@ -611,6 +611,53 @@ hq 'resource[*] | {type: .block_type, name: .name_labels}' main.tf --json
 # Hybrid mode — Python expression on structural results
 hq 'variable[select(.default)]::name_labels[0] + " = " + str(_.attribute("default").value)' variables.tf --value
 ```
+
+## Piping to jq
+
+hq handles structural HCL navigation (blocks, labels, type filters, predicates). For data transforms on the results, pipe `--json` or `--ndjson` output to jq:
+
+```sh
+# Defaults — fill missing values
+hq 'resource~[*] | {name: .name_labels, tags}' main.tf --json | jq '.tags // "none"'
+
+# Reshaping — extract specific fields into arrays
+hq 'resource[*]' main.tf --json | jq '[.block_type, .name]'
+
+# Mapping — transform each result
+hq 'module~[*] | .source' dir/ --ndjson | jq -r 'ascii_downcase'
+
+# Filtering on JSON values
+hq 'resource~[*]' main.tf --ndjson | jq 'select(.count > 3)'
+
+# Aggregation — group or sort across results
+hq 'resource[*]' dir/ --ndjson | jq -s 'group_by(.block_type)'
+```
+
+**Mental model:** hq navigates HCL structure (block types, labels, attributes, nesting). Once you have `--json` output, you're in jq's world — use jq for arithmetic, string transforms, reshaping, defaults, and aggregation.
+
+## Coming from jq
+
+| jq | hq equivalent | Notes |
+|---|---|---|
+| `.key` | `.key` | Same syntax |
+| `.[]` | `.[]` or `[*]` | `.[]` is an alias for `[*]` |
+| `.[N]` | `[N]` | Zero-based index |
+| `select(.x == "y")` | `[select(.x == "y")]` | Bracket or pipe syntax |
+| `keys` | `\| keys` | Pipe stage |
+| `length` | `\| length` | Pipe stage |
+| `has("key")` | `[select(has("key"))]` | Inside select predicates |
+| `contains("str")` | `[select(.field \| contains("str"))]` | Inside select predicates |
+| `test("regex")` | `[select(.field \| test("regex"))]` | Inside select predicates |
+| `{a, b}` | `{a, b}` | Object construction |
+| `{newkey: .old}` | `{newkey: .old}` | Renamed keys |
+| `map(.f)` | — | `--json \| jq 'map(.f)'` |
+| `.x // "default"` | — | `--json \| jq '.x // "default"'` |
+| `[.x, .y]` | — | `--json \| jq '[.x, .y]'` |
+| `group_by(.f)` | — | `--ndjson \| jq -s 'group_by(.f)'` |
+| `sort_by(.f)` | — | `--ndjson \| jq -s 'sort_by(.f)'` |
+| `if-then-else` | — | `--json \| jq 'if ...'` or hybrid (`::`) mode |
+
+Features unique to hq (no jq equivalent): block type navigation (`resource.aws_instance`), label traversal, skip labels (`~`), type qualifiers (`function_call:name`), recursive descent (`..`), `--describe` / `--schema` introspection.
 
 ## See Also
 

--- a/hcl2/query/path.py
+++ b/hcl2/query/path.py
@@ -41,6 +41,9 @@ def parse_path(path_str: str) -> List[PathSegment]:  # pylint: disable=too-many-
     if not path_str or not path_str.strip():
         raise QuerySyntaxError("Empty path")
 
+    # jq compat: .[] is an alias for [*]
+    path_str = path_str.replace(".[]", "[*]")
+
     segments: List[PathSegment] = []
     parts = _split_path(path_str)
 

--- a/test/unit/query/test_path.py
+++ b/test/unit/query/test_path.py
@@ -189,3 +189,25 @@ class TestParsePath(TestCase):
         segments = parse_path('*[select(.name == "a\\"b")]')
         self.assertEqual(len(segments), 1)
         self.assertIsNotNone(segments[0].predicate)
+
+    # jq compat: .[] as alias for [*]
+
+    def test_jq_iterate_alias(self):
+        """resource.[] is equivalent to resource[*]"""
+        segments = parse_path("resource.[]")
+        expected = parse_path("resource[*]")
+        self.assertEqual(segments, expected)
+
+    def test_jq_iterate_alias_chained(self):
+        """a.b.[] normalizes to a.b[*]"""
+        segments = parse_path("a.b.[]")
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[0].name, "a")
+        self.assertEqual(segments[1].name, "b")
+        self.assertTrue(segments[1].select_all)
+
+    def test_jq_iterate_alias_with_continuation(self):
+        """resource.[].tags normalizes to resource[*].tags"""
+        segments = parse_path("resource.[].tags")
+        expected = parse_path("resource[*].tags")
+        self.assertEqual(segments, expected)


### PR DESCRIPTION
## Summary

Lowers the learning curve for users coming from jq by adding `.[]` as an alias for `[*]` in hq path expressions, and adds documentation showing how hq and jq complement each other.

## Changes

- Add `.[]` → `[*]` normalization in `parse_path()` so jq-style iteration syntax works in hq queries
- Add "Piping to jq" section to hq docs with practical examples of combining hq + jq
- Add "Coming from jq" translation table mapping common jq idioms to their hq equivalents
- Add unit tests for the `.[]` alias in standalone, chained, and continuation positions

## Manual testing checklist

- [ ] `hq 'resource.[]' file.tf` produces the same output as `hq 'resource[*]' file.tf`
- [ ] `hq 'resource.[].tags' file.tf` works with continuation after the alias
- [ ] Existing `[*]` queries are unaffected

---

🤖 Co-Authored-By: Claude Opus 4.6 (1M context) [Claude Code](https://claude.com/claude-code)