### PR TITLE
Refactor hq CLI for readability and reduced complexity

### DIFF
--- a/cli/hq.py
+++ b/cli/hq.py
@@ -667,12 +667,6 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     serialization_options = None
     if args.with_comments:
         serialization_options = SerializationOptions(with_comments=True)
-        print(
-            "Warning: --with-comments only includes comments for top-level body "
-            "queries (e.g. 'resource[*]' on a single file). Comments adjacent to "
-            "individual blocks are not yet captured by sub-block queries.",
-            file=sys.stderr,
-        )
 
     # --schema: dump schema and exit
     if args.schema:

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -23,12 +23,25 @@ from hcl2.query.safe_eval import (
 from hcl2.version import __version__
 from .helpers import _expand_file_args  # noqa: F401 — re-exported for tests
 
-# Exit codes
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
 EXIT_SUCCESS = 0
 EXIT_NO_RESULTS = 1
 EXIT_PARSE_ERROR = 2
 EXIT_QUERY_ERROR = 3
 EXIT_IO_ERROR = 4
+
+_EXIT_TO_ERROR_TYPE = {
+    EXIT_IO_ERROR: "io_error",
+    EXIT_PARSE_ERROR: "parse_error",
+    EXIT_QUERY_ERROR: "query_error",
+}
+
+_HCL_EXTENSIONS = {".tf", ".hcl", ".tfvars"}
+
+_EVAL_PREFIXES = tuple(f"{name}(" for name in sorted(_SAFE_CALLABLE_NAMES)) + ("doc",)
 
 EXAMPLES_TEXT = """\
 examples:
@@ -95,8 +108,126 @@ examples:
 docs: https://github.com/amplify-education/python-hcl2/tree/main/docs
 """
 
+# ---------------------------------------------------------------------------
+# Helpers: strings
+# ---------------------------------------------------------------------------
 
-_EVAL_PREFIXES = tuple(f"{name}(" for name in sorted(_SAFE_CALLABLE_NAMES)) + ("doc",)
+
+def _strip_dollar_wrap(text: str) -> str:
+    """Strip ``${...}`` wrapping from a serialized expression string."""
+    if text.startswith("${") and text.endswith("}"):
+        return text[2:-1]
+    return text
+
+
+def _strip_quotes(text: str) -> str:
+    """Strip surrounding quotes from a string value."""
+    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
+        return text[1:-1]
+    return text
+
+
+def _rawify(value: Any) -> Any:
+    """Recursively strip quotes and ${} wrapping from all string values."""
+    if isinstance(value, str):
+        return _strip_dollar_wrap(_strip_quotes(value))
+    if isinstance(value, dict):
+        return {k: _rawify(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_rawify(v) for v in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Helpers: I/O & errors
+# ---------------------------------------------------------------------------
+
+
+def _read_input(path: str) -> str:
+    """Read from a file path, or stdin if path is ``-``."""
+    if path == "-":
+        return sys.stdin.read()
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _collect_files(path: str) -> List[str]:
+    """Return a list of HCL file paths from a file path, directory, or stdin marker."""
+    if path == "-":
+        return ["-"]
+    if os.path.isdir(path):
+        return sorted(
+            os.path.join(dp, fn)
+            for dp, _, fnames in os.walk(path)
+            for fn in fnames
+            if os.path.splitext(fn)[1] in _HCL_EXTENSIONS
+        )
+    return [path]
+
+
+# _expand_file_args is imported from .helpers and re-exported at module level.
+
+
+def _error(msg: str, use_json: bool, **extra) -> str:
+    """Format an error message."""
+    if use_json:
+        return json.dumps(
+            {"error": extra.get("error_type", "error"), "message": msg, **extra}
+        )
+    return f"Error: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers: JSON conversion & result metadata
+# ---------------------------------------------------------------------------
+
+
+def _convert_for_json(
+    value: Any,
+    options: Optional[SerializationOptions] = None,
+) -> Any:
+    """Recursively convert NodeViews to dicts for JSON serialization."""
+    if isinstance(value, NodeView):
+        return value.to_dict(options=options)
+    if isinstance(value, list):
+        return [_convert_for_json(item, options=options) for item in value]
+    return value
+
+
+def _inject_provenance(converted: Any, file_path: str) -> Any:
+    """Add ``__file__`` key to dict results for multi-file provenance."""
+    if isinstance(converted, dict):
+        return {"__file__": file_path, **converted}
+    return converted
+
+
+def _extract_location(result: Any, file_path: str) -> dict:
+    """Extract source location metadata from a result."""
+    from hcl2.query.pipeline import _LocatedDict
+
+    loc: dict = {"__file__": file_path}
+    meta = None
+    if isinstance(result, NodeView):
+        meta = getattr(result.raw, "_meta", None)
+    elif isinstance(result, _LocatedDict):
+        meta = result._source_meta
+    if meta is not None:
+        for attr in ("line", "end_line", "column", "end_column"):
+            if hasattr(meta, attr):
+                loc[f"__{attr}__"] = getattr(meta, attr)
+    return loc
+
+
+def _merge_location(converted: Any, location: dict) -> Any:
+    """Merge location metadata into a converted JSON value."""
+    if isinstance(converted, dict):
+        return {**location, **converted}
+    return {"__value__": converted, **location}
+
+
+# ---------------------------------------------------------------------------
+# Query dispatch
+# ---------------------------------------------------------------------------
 
 
 def _normalize_eval_expr(expr_part: str) -> str:
@@ -142,41 +273,9 @@ def _dispatch_query(
     return execute_pipeline(doc_view, stages, file_path=file_path)
 
 
-def _strip_dollar_wrap(text: str) -> str:
-    """Strip ``${...}`` wrapping from a serialized expression string."""
-    if text.startswith("${") and text.endswith("}"):
-        return text[2:-1]
-    return text
-
-
-def _strip_quotes(text: str) -> str:
-    """Strip surrounding quotes from a string value."""
-    if len(text) >= 2 and text[0] == '"' and text[-1] == '"':
-        return text[1:-1]
-    return text
-
-
-def _rawify(value: Any) -> Any:
-    """Recursively strip quotes and ${} wrapping from all string values."""
-    if isinstance(value, str):
-        return _strip_dollar_wrap(_strip_quotes(value))
-    if isinstance(value, dict):
-        return {k: _rawify(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_rawify(v) for v in value]
-    return value
-
-
-def _convert_for_json(
-    value: Any,
-    options: Optional[SerializationOptions] = None,
-) -> Any:
-    """Recursively convert NodeViews to dicts for JSON serialization."""
-    if isinstance(value, NodeView):
-        return value.to_dict(options=options)
-    if isinstance(value, list):
-        return [_convert_for_json(item, options=options) for item in value]
-    return value
+# ---------------------------------------------------------------------------
+# Output: formatting & lifecycle
+# ---------------------------------------------------------------------------
 
 
 @dataclasses.dataclass
@@ -273,27 +372,175 @@ class OutputConfig:
                 for item in results
             ]
             return json.dumps(items, indent=self.json_indent, default=str)
-
-        parts = []
-        for result in results:
-            parts.append(self.format_result(result))
-        return "\n".join(parts)
+        return "\n".join(self.format_result(r) for r in results)
 
 
-_EXIT_TO_ERROR_TYPE = {
-    EXIT_IO_ERROR: "io_error",
-    EXIT_PARSE_ERROR: "parse_error",
-    EXIT_QUERY_ERROR: "query_error",
-}
+def _convert_results(
+    results: List[Any],
+    file_path: str,
+    multi: bool,
+    output_config: OutputConfig,
+) -> List[Any]:
+    """Convert query results for JSON output with location/provenance metadata."""
+    converted = []
+    for result in results:
+        item = _convert_for_json(result, options=output_config.serialization_options)
+        if output_config.with_location:
+            loc = _extract_location(result, file_path)
+            item = _merge_location(item, loc)
+        elif multi and not output_config.no_filename:
+            item = _inject_provenance(item, file_path)
+        converted.append(item)
+    return converted
 
 
-def _error(msg: str, use_json: bool, **extra) -> str:
-    """Format an error message."""
-    if use_json:
-        data = {"error": extra.get("error_type", "error"), "message": msg}
-        data.update(extra)
-        return json.dumps(data)
-    return f"Error: {msg}"
+class OutputSink:
+    """Owns the result output lifecycle: stream or accumulate, then flush."""
+
+    def __init__(self, output_config: OutputConfig, multi: bool):
+        self.config = output_config
+        self.multi = multi
+        self._accumulator: List[Any] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.flush()
+        return False
+
+    def emit(self, results: List[Any], file_path: str) -> None:
+        """Emit raw query results for one file (serial path)."""
+        # NDJSON — stream immediately
+        if self.config.ndjson:
+            for item in _convert_results(results, file_path, self.multi, self.config):
+                line = json.dumps(item, default=str)
+                if (
+                    self.multi
+                    and not self.config.no_filename
+                    and not self.config.with_location
+                    and not isinstance(item, dict)
+                ):
+                    line = f"{file_path}:{line}"
+                print(line, flush=True)
+            return
+
+        # JSON + multi — accumulate for merged output
+        if self.config.output_json and self.multi:
+            self._accumulator.extend(
+                _convert_results(results, file_path, self.multi, self.config)
+            )
+            return
+
+        # Single-file output (with_location or default)
+        if self.config.with_location:
+            items = _convert_results(results, file_path, self.multi, self.config)
+            data = items[0] if len(items) == 1 else items
+            output = json.dumps(data, indent=self.config.json_indent, default=str)
+        else:
+            output = self.config.format_output(results)
+
+        if self.multi and not self.config.no_filename and not self.config.with_location:
+            prefix = f"{file_path}:"
+            print("\n".join(prefix + ln for ln in output.splitlines()))
+        else:
+            print(output)
+
+    def emit_converted(self, converted: List[Any]) -> None:
+        """Emit pre-converted results (parallel path)."""
+        if self.config.ndjson:
+            for item in converted:
+                print(json.dumps(item, default=str), flush=True)
+        elif self.config.output_json and self.multi:
+            self._accumulator.extend(converted)
+
+    def flush(self) -> None:
+        """Sort and emit accumulated JSON results."""
+        if not self._accumulator:
+            return
+        self._accumulator.sort(
+            key=lambda x: x.get("__file__", "") if isinstance(x, dict) else ""
+        )
+        print(
+            json.dumps(self._accumulator, indent=self.config.json_indent, default=str)
+        )
+        self._accumulator.clear()
+
+
+# ---------------------------------------------------------------------------
+# File-level query execution
+# ---------------------------------------------------------------------------
+
+
+def _run_query_on_file(
+    file_path: str,
+    query: str,
+    is_eval: bool,
+    use_json: bool,
+    raw_query: str,
+) -> Tuple[Optional[List[Any]], int]:
+    """Parse a file and run a query.
+
+    Returns ``(results, exit_code)``.  On error, results is ``None`` and
+    exit_code is one of the ``EXIT_*`` constants.
+    """
+    try:
+        text = _read_input(file_path)
+    except (OSError, IOError) as exc:
+        print(_error(str(exc), use_json, error_type="io_error"), file=sys.stderr)
+        return None, EXIT_IO_ERROR
+
+    try:
+        doc = DocumentView.parse(text)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(
+            _error(str(exc), use_json, error_type="parse_error", file=file_path),
+            file=sys.stderr,
+        )
+        return None, EXIT_PARSE_ERROR
+
+    try:
+        return _dispatch_query(query, is_eval, doc, file_path=file_path), EXIT_SUCCESS
+    except Exception as exc:  # pylint: disable=broad-except
+        if isinstance(exc, QuerySyntaxError):
+            extra = {"error_type": "query_syntax", "query": raw_query}
+        elif isinstance(exc, UnsafeExpressionError):
+            extra = {"error_type": "unsafe_expression", "expression": raw_query}
+        else:
+            extra = {"error_type": "eval_error", "query": raw_query}
+        print(_error(str(exc), use_json, **extra), file=sys.stderr)
+        return None, EXIT_QUERY_ERROR
+
+
+def _process_file(args_tuple):
+    """Worker: parse, query, and convert results for one file.
+
+    Returns ``(file_path, exit_code, converted_results, error_msg)``.
+    All return values are picklable plain Python objects.
+    """
+    file_path, query, is_eval, raw_query, multi, output_config = args_tuple
+
+    try:
+        text = _read_input(file_path)
+    except (OSError, IOError) as exc:
+        return (file_path, EXIT_IO_ERROR, None, str(exc))
+
+    try:
+        doc = DocumentView.parse(text)
+    except Exception as exc:  # pylint: disable=broad-except
+        return (file_path, EXIT_PARSE_ERROR, None, str(exc))
+
+    try:
+        results = _dispatch_query(query, is_eval, doc, file_path=file_path)
+    except Exception as exc:  # pylint: disable=broad-except
+        return (file_path, EXIT_QUERY_ERROR, None, str(exc))
+
+    if not results:
+        return (file_path, EXIT_SUCCESS, [], None)
+
+    converted = _convert_results(results, file_path, multi, output_config)
+
+    return (file_path, EXIT_SUCCESS, converted, None)
 
 
 def _run_diff(
@@ -321,16 +568,8 @@ def _run_diff(
             sys.exit(EXIT_IO_ERROR)
 
     try:
-        if file1 == "-":
-            text1 = sys.stdin.read()
-        else:
-            with open(file1, encoding="utf-8") as f:
-                text1 = f.read()
-        if file2 == "-":
-            text2 = sys.stdin.read()
-        else:
-            with open(file2, encoding="utf-8") as f:
-                text2 = f.read()
+        text1 = _read_input(file1)
+        text2 = _read_input(file2)
     except (OSError, IOError) as exc:
         print(_error(str(exc), use_json, error_type="io_error"), file=sys.stderr)
         sys.exit(EXIT_IO_ERROR)
@@ -353,172 +592,9 @@ def _run_diff(
     return EXIT_NO_RESULTS
 
 
-_HCL_EXTENSIONS = {".tf", ".hcl", ".tfvars"}
-
-
-def _collect_files(path: str) -> List[str]:
-    """Return a list of HCL file paths from a file path, directory, or stdin marker."""
-    if path == "-":
-        return ["-"]
-    if os.path.isdir(path):
-        files = []
-        for dirpath, _, filenames in os.walk(path):
-            for fname in sorted(filenames):
-                if os.path.splitext(fname)[1] in _HCL_EXTENSIONS:
-                    files.append(os.path.join(dirpath, fname))
-        files.sort()
-        return files
-    return [path]
-
-
-# _expand_file_args is imported from .helpers and re-exported at module level.
-
-
-def _run_query_on_file(
-    file_path: str,
-    query: str,
-    is_eval: bool,
-    use_json: bool,
-    raw_query: str,
-) -> Tuple[Optional[List[Any]], int]:
-    """Parse a file and run a query.
-
-    Returns ``(results, exit_code)``.  On error, results is ``None`` and
-    exit_code is one of the ``EXIT_*`` constants.
-    """
-    try:
-        if file_path == "-":
-            text = sys.stdin.read()
-        else:
-            with open(file_path, encoding="utf-8") as f:
-                text = f.read()
-    except (OSError, IOError) as exc:
-        print(_error(str(exc), use_json, error_type="io_error"), file=sys.stderr)
-        return None, EXIT_IO_ERROR
-
-    try:
-        doc = DocumentView.parse(text)
-    except Exception as exc:  # pylint: disable=broad-except
-        print(
-            _error(str(exc), use_json, error_type="parse_error", file=file_path),
-            file=sys.stderr,
-        )
-        return None, EXIT_PARSE_ERROR
-
-    try:
-        return _dispatch_query(query, is_eval, doc, file_path=file_path), EXIT_SUCCESS
-    except QuerySyntaxError as exc:
-        print(
-            _error(str(exc), use_json, error_type="query_syntax", query=raw_query),
-            file=sys.stderr,
-        )
-        return None, EXIT_QUERY_ERROR
-    except UnsafeExpressionError as exc:
-        print(
-            _error(
-                str(exc),
-                use_json,
-                error_type="unsafe_expression",
-                expression=raw_query,
-            ),
-            file=sys.stderr,
-        )
-        return None, EXIT_QUERY_ERROR
-    except Exception as exc:  # pylint: disable=broad-except
-        print(
-            _error(str(exc), use_json, error_type="eval_error", query=raw_query),
-            file=sys.stderr,
-        )
-        return None, EXIT_QUERY_ERROR
-
-
-def _inject_provenance(converted: Any, file_path: str) -> Any:
-    """Add ``__file__`` key to dict results for multi-file provenance."""
-    if isinstance(converted, dict):
-        return {"__file__": file_path, **converted}
-    return converted
-
-
-def _extract_location(result: Any, file_path: str) -> dict:
-    """Extract source location metadata from a result."""
-    from hcl2.query.pipeline import _LocatedDict
-
-    loc: dict = {"__file__": file_path}
-    meta = None
-    if isinstance(result, NodeView):
-        meta = getattr(result.raw, "_meta", None)
-    elif isinstance(result, _LocatedDict):
-        meta = result._source_meta
-    if meta is not None:
-        if hasattr(meta, "line"):
-            loc["__line__"] = meta.line
-        if hasattr(meta, "end_line"):
-            loc["__end_line__"] = meta.end_line
-        if hasattr(meta, "column"):
-            loc["__column__"] = meta.column
-        if hasattr(meta, "end_column"):
-            loc["__end_column__"] = meta.end_column
-    return loc
-
-
-def _merge_location(converted: Any, location: dict) -> Any:
-    """Merge location metadata into a converted JSON value."""
-    if isinstance(converted, dict):
-        return {**location, **converted}
-    return {"__value__": converted, **location}
-
-
-def _convert_results(
-    results: List[Any],
-    file_path: str,
-    multi: bool,
-    output_config: OutputConfig,
-) -> List[Any]:
-    """Convert query results for JSON output with location/provenance metadata."""
-    converted = []
-    for result in results:
-        item = _convert_for_json(result, options=output_config.serialization_options)
-        if output_config.with_location:
-            loc = _extract_location(result, file_path)
-            item = _merge_location(item, loc)
-        elif multi and not output_config.no_filename:
-            item = _inject_provenance(item, file_path)
-        converted.append(item)
-    return converted
-
-
-def _process_file(args_tuple):
-    """Worker: parse, query, and convert results for one file.
-
-    Returns ``(file_path, exit_code, converted_results, error_msg)``.
-    All return values are picklable plain Python objects.
-    """
-    file_path, query, is_eval, raw_query, multi, output_config = args_tuple
-
-    try:
-        with open(file_path, encoding="utf-8") as f:
-            text = f.read()
-    except (OSError, IOError) as exc:
-        return (file_path, EXIT_IO_ERROR, None, str(exc))
-
-    try:
-        doc = DocumentView.parse(text)
-    except Exception as exc:  # pylint: disable=broad-except
-        return (file_path, EXIT_PARSE_ERROR, None, str(exc))
-
-    try:
-        results = _dispatch_query(query, is_eval, doc, file_path=file_path)
-    except (QuerySyntaxError, UnsafeExpressionError) as exc:
-        return (file_path, EXIT_QUERY_ERROR, None, str(exc))
-    except Exception as exc:  # pylint: disable=broad-except
-        return (file_path, EXIT_QUERY_ERROR, None, str(exc))
-
-    if not results:
-        return (file_path, EXIT_SUCCESS, [], None)
-
-    converted = _convert_results(results, file_path, multi, output_config)
-
-    return (file_path, EXIT_SUCCESS, converted, None)
+# ---------------------------------------------------------------------------
+# CLI: argument parsing & orchestration
+# ---------------------------------------------------------------------------
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -712,54 +788,7 @@ def _resolve_query(
     return query, optional
 
 
-def _emit_file_results(
-    results: List[Any],
-    file_path: str,
-    multi: bool,
-    output_config: OutputConfig,
-    json_accumulator: List[Any],
-) -> None:
-    """Format and emit query results for one file."""
-    # NDJSON mode: one JSON object per line (streaming, no accumulation)
-    if output_config.ndjson:
-        items = _convert_results(results, file_path, multi, output_config)
-        for item in items:
-            line = json.dumps(item, default=str)
-            if (
-                multi
-                and not output_config.no_filename
-                and not output_config.with_location
-            ):
-                # provenance already injected into dict; for non-dicts
-                # prefix with filename
-                if not isinstance(item, dict):
-                    line = f"{file_path}:{line}"
-            print(line, flush=True)
-        return
-
-    # JSON mode with multiple files: accumulate for merged output
-    if output_config.output_json and multi:
-        json_accumulator.extend(
-            _convert_results(results, file_path, multi, output_config)
-        )
-        return
-
-    # Single-file JSON with location
-    if output_config.with_location:
-        items = _convert_results(results, file_path, multi, output_config)
-        data = items[0] if len(items) == 1 else items
-        output = json.dumps(data, indent=output_config.json_indent, default=str)
-    else:
-        output = output_config.format_output(results)
-
-    if multi and not output_config.no_filename and not output_config.with_location:
-        prefix = f"{file_path}:"
-        print("\n".join(prefix + line for line in output.splitlines()))
-    else:
-        print(output)
-
-
-def _execute_and_emit(  # pylint: disable=too-many-branches
+def _execute_and_emit(
     args: argparse.Namespace,
     query: str,
     optional: bool,
@@ -767,17 +796,13 @@ def _execute_and_emit(  # pylint: disable=too-many-branches
     output_config: OutputConfig,
 ) -> int:
     """Execute queries across files and emit results. Returns an exit code."""
-    expanded_args = _expand_file_args(args.FILE)
-    file_paths: List[str] = []
-    for file_arg in expanded_args:
-        file_paths.extend(_collect_files(file_arg))
-
+    file_paths = [
+        fp for fa in _expand_file_args(args.FILE) for fp in _collect_files(fa)
+    ]
     any_results = False
     worst_exit = EXIT_SUCCESS
-    json_accumulator: List[Any] = []
     multi = len(file_paths) > 1
 
-    # Decide whether to use parallel processing
     use_parallel = (
         multi
         and len(file_paths) >= 20
@@ -787,65 +812,45 @@ def _execute_and_emit(  # pylint: disable=too-many-branches
         and (args.json or args.ndjson)
         and (args.jobs is None or args.jobs > 1)
     )
-    if args.jobs is not None and args.jobs <= 1:
-        use_parallel = False
 
-    if use_parallel:
-        n_workers = args.jobs or min(os.cpu_count() or 1, len(file_paths))
-        worker_args = [
-            (fp, query, False, args.QUERY, multi, output_config) for fp in file_paths
-        ]
-
-        with multiprocessing.Pool(n_workers) as pool:
-            for file_path, exit_code, converted, error_msg in pool.imap_unordered(
-                _process_file, worker_args
-            ):
-                if error_msg:
-                    etype = _EXIT_TO_ERROR_TYPE.get(exit_code, "error")
-                    print(
-                        _error(error_msg, use_json, error_type=etype),
-                        file=sys.stderr,
-                    )
+    with OutputSink(output_config, multi) as sink:
+        if use_parallel:
+            n_workers = args.jobs or min(os.cpu_count() or 1, len(file_paths))
+            worker_args = [
+                (fp, query, False, args.QUERY, multi, output_config)
+                for fp in file_paths
+            ]
+            with multiprocessing.Pool(n_workers) as pool:
+                for fp, exit_code, converted, error_msg in pool.imap_unordered(
+                    _process_file, worker_args
+                ):
+                    if error_msg:
+                        etype = _EXIT_TO_ERROR_TYPE.get(exit_code, "error")
+                        print(
+                            _error(error_msg, use_json, error_type=etype),
+                            file=sys.stderr,
+                        )
+                        worst_exit = max(worst_exit, exit_code)
+                        continue
+                    if not converted:
+                        continue
+                    any_results = True
+                    sink.emit_converted(converted)
+        else:
+            for file_path in file_paths:
+                results, exit_code = _run_query_on_file(
+                    file_path, query, args.eval, use_json, args.QUERY
+                )
+                if results is None:
                     worst_exit = max(worst_exit, exit_code)
                     continue
-                if not converted:
+                if not results:
                     continue
                 any_results = True
-
-                if args.ndjson:
-                    for item in converted:
-                        print(json.dumps(item, default=str), flush=True)
-                elif args.json and multi:
-                    json_accumulator.extend(converted)
-    else:
-        for file_path in file_paths:
-            results, exit_code = _run_query_on_file(
-                file_path, query, args.eval, use_json, args.QUERY
-            )
-            if results is None:
-                worst_exit = max(worst_exit, exit_code)
-                continue  # parse/query error already printed
-            if not results:
-                continue
-            any_results = True
-
-            if args.describe:
-                print(json.dumps(describe_results(results), indent=2))
-                continue
-
-            _emit_file_results(
-                results, file_path, multi, output_config, json_accumulator
-            )
-
-    # Emit accumulated JSON results as a single merged array
-    if json_accumulator:
-        # Sort by __file__ for deterministic output (parallel uses imap_unordered)
-        json_accumulator.sort(
-            key=lambda x: x.get("__file__", "") if isinstance(x, dict) else ""
-        )
-        print(
-            json.dumps(json_accumulator, indent=output_config.json_indent, default=str)
-        )
+                if args.describe:
+                    print(json.dumps(describe_results(results), indent=2))
+                    continue
+                sink.emit(results, file_path)
 
     if any_results:
         return EXIT_SUCCESS

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -521,8 +521,8 @@ def _process_file(args_tuple):
     return (file_path, EXIT_SUCCESS, converted, None)
 
 
-def main():  # pylint: disable=too-many-branches,too-many-statements
-    """The ``hq`` console_scripts entry point."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for ``hq``."""
     parser = argparse.ArgumentParser(
         prog="hq",
         description=(
@@ -618,10 +618,14 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         metavar="N",
         help="Parallel workers (default: auto for large file sets, 0 or 1 = serial)",
     )
+    return parser
 
-    args = parser.parse_args()
 
-    # Validate --ndjson compatibility
+def _validate_and_configure(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+) -> Tuple[bool, OutputConfig]:
+    """Validate argument combinations and build output configuration."""
     if args.ndjson:
         if args.value:
             parser.error("--ndjson cannot be combined with --value")
@@ -639,15 +643,11 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     else:
         json_indent = None
 
-    # Validate --with-location
     if args.with_location and not use_json:
         parser.error("--with-location requires --json or --ndjson")
-
-    # Validate --with-comments
     if args.with_comments and not use_json:
         parser.error("--with-comments requires --json or --ndjson")
 
-    # Build serialization options
     serialization_options = None
     if args.with_comments:
         serialization_options = SerializationOptions(with_comments=True)
@@ -663,29 +663,38 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         no_filename=args.no_filename,
         serialization_options=serialization_options,
     )
+    return use_json, output_config
 
+
+def _resolve_query(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+    use_json: bool,
+    output_config: OutputConfig,
+) -> Tuple[str, bool]:
+    """Handle early exits and resolve the query string.
+
+    May call ``sys.exit`` for ``--schema``/``--diff`` or ``parser.error``
+    for invalid arguments and never return.  Otherwise returns
+    ``(query, optional)``.
+    """
     # --schema: dump schema and exit
     if args.schema:
         print(json.dumps(build_schema(), indent=2))
         sys.exit(EXIT_SUCCESS)
 
     # --diff: structural diff mode
-    # Usage: hq FILE1 --diff FILE2  (FILE1 is the first positional arg)
     if args.diff:
         file1 = args.QUERY
         if file1 is None:
             parser.error("--diff requires two files: hq FILE1 --diff FILE2")
-        sys.exit(_run_diff(file1, args.diff, use_json, json_indent))
+        sys.exit(_run_diff(file1, args.diff, use_json, output_config.json_indent))
 
     # QUERY is required unless --schema or --diff
     if args.QUERY is None:
         parser.error("the following arguments are required: QUERY")
 
     # Detect common mistake: user passed a file path but no query.
-    # When only one positional arg is given, argparse puts it in QUERY
-    # and FILE defaults to ["-"].  If stdin is a TTY (not piped) and
-    # QUERY looks like a file/directory path, give a helpful error
-    # instead of hanging on stdin.
     if (
         args.FILE == ["-"]
         and sys.stdin.isatty()
@@ -700,7 +709,17 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     if optional:
         query = query.rstrip()[:-1].rstrip()
 
-    # Expand globs and collect input files
+    return query, optional
+
+
+def _execute_and_emit(  # pylint: disable=too-many-branches,too-many-statements
+    args: argparse.Namespace,
+    query: str,
+    optional: bool,
+    use_json: bool,
+    output_config: OutputConfig,
+) -> int:
+    """Execute queries across files and emit results. Returns an exit code."""
     expanded_args = _expand_file_args(args.FILE)
     file_paths: List[str] = []
     for file_arg in expanded_args:
@@ -708,7 +727,6 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
     any_results = False
     worst_exit = EXIT_SUCCESS
-    # Collect JSON results across files for a single merged array
     json_accumulator: List[Any] = []
     multi = len(file_paths) > 1
 
@@ -792,9 +810,13 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
             if args.with_location:
                 items = _convert_results(results, file_path, multi, output_config)
                 if len(items) == 1:
-                    output = json.dumps(items[0], indent=json_indent, default=str)
+                    output = json.dumps(
+                        items[0], indent=output_config.json_indent, default=str
+                    )
                 else:
-                    output = json.dumps(items, indent=json_indent, default=str)
+                    output = json.dumps(
+                        items, indent=output_config.json_indent, default=str
+                    )
             else:
                 output = output_config.format_output(results)
 
@@ -810,11 +832,22 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
         json_accumulator.sort(
             key=lambda x: x.get("__file__", "") if isinstance(x, dict) else ""
         )
-        print(json.dumps(json_accumulator, indent=json_indent, default=str))
+        print(
+            json.dumps(json_accumulator, indent=output_config.json_indent, default=str)
+        )
 
     if any_results:
-        sys.exit(EXIT_SUCCESS)
-    sys.exit(EXIT_SUCCESS if optional else worst_exit or EXIT_NO_RESULTS)
+        return EXIT_SUCCESS
+    return EXIT_SUCCESS if optional else worst_exit or EXIT_NO_RESULTS
+
+
+def main():
+    """The ``hq`` console_scripts entry point."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    use_json, output_config = _validate_and_configure(parser, args)
+    query, optional = _resolve_query(args, parser, use_json, output_config)
+    sys.exit(_execute_and_emit(args, query, optional, use_json, output_config))
 
 
 if __name__ == "__main__":

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -482,6 +482,27 @@ def _merge_location(converted: Any, location: dict) -> Any:
     return {"__value__": converted, **location}
 
 
+def _convert_results(
+    results: List[Any],
+    file_path: str,
+    with_location: bool,
+    multi: bool,
+    no_filename: bool,
+    serialization_options: Optional[SerializationOptions],
+) -> List[Any]:
+    """Convert query results for JSON output with location/provenance metadata."""
+    converted = []
+    for result in results:
+        item = _convert_for_json(result, options=serialization_options)
+        if with_location:
+            loc = _extract_location(result, file_path)
+            item = _merge_location(item, loc)
+        elif multi and not no_filename:
+            item = _inject_provenance(item, file_path)
+        converted.append(item)
+    return converted
+
+
 def _process_file(args_tuple):  # pylint: disable=too-many-locals
     """Worker: parse, query, and convert results for one file.
 
@@ -524,15 +545,9 @@ def _process_file(args_tuple):  # pylint: disable=too-many-locals
     if not results:
         return (file_path, EXIT_SUCCESS, [], None)
 
-    converted = []
-    for result in results:
-        item = _convert_for_json(result, options=ser_opts)
-        if with_location:
-            loc = _extract_location(result, file_path)
-            item = _merge_location(item, loc)
-        elif multi and not no_filename:
-            item = _inject_provenance(item, file_path)
-        converted.append(item)
+    converted = _convert_results(
+        results, file_path, with_location, multi, no_filename, ser_opts
+    )
 
     return (file_path, EXIT_SUCCESS, converted, None)
 
@@ -786,41 +801,48 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
             # NDJSON mode: one JSON object per line (streaming, no accumulation)
             if args.ndjson:
-                for result in results:
-                    converted = _convert_for_json(result, options=serialization_options)
-                    if args.with_location:
-                        loc = _extract_location(result, file_path)
-                        converted = _merge_location(converted, loc)
-                    elif multi and not args.no_filename:
-                        converted = _inject_provenance(converted, file_path)
-                    line = json.dumps(converted, default=str)
+                items = _convert_results(
+                    results,
+                    file_path,
+                    args.with_location,
+                    multi,
+                    args.no_filename,
+                    serialization_options,
+                )
+                for item in items:
+                    line = json.dumps(item, default=str)
                     if multi and not args.no_filename and not args.with_location:
                         # provenance already injected into dict; for non-dicts
                         # prefix with filename
-                        if not isinstance(converted, dict):
+                        if not isinstance(item, dict):
                             line = f"{file_path}:{line}"
                     print(line, flush=True)
                 continue
 
             # JSON mode with multiple files: accumulate for merged output
             if args.json and multi:
-                for result in results:
-                    converted = _convert_for_json(result, options=serialization_options)
-                    if args.with_location:
-                        loc = _extract_location(result, file_path)
-                        converted = _merge_location(converted, loc)
-                    elif not args.no_filename:
-                        converted = _inject_provenance(converted, file_path)
-                    json_accumulator.append(converted)
+                json_accumulator.extend(
+                    _convert_results(
+                        results,
+                        file_path,
+                        args.with_location,
+                        multi,
+                        args.no_filename,
+                        serialization_options,
+                    )
+                )
                 continue
 
             # Single-file JSON with location
             if args.with_location:
-                items = []
-                for result in results:
-                    converted = _convert_for_json(result, options=serialization_options)
-                    loc = _extract_location(result, file_path)
-                    items.append(_merge_location(converted, loc))
+                items = _convert_results(
+                    results,
+                    file_path,
+                    True,
+                    multi,
+                    args.no_filename,
+                    serialization_options,
+                )
                 if len(items) == 1:
                     output = json.dumps(items[0], indent=json_indent, default=str)
                 else:

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -712,7 +712,54 @@ def _resolve_query(
     return query, optional
 
 
-def _execute_and_emit(  # pylint: disable=too-many-branches,too-many-statements
+def _emit_file_results(
+    results: List[Any],
+    file_path: str,
+    multi: bool,
+    output_config: OutputConfig,
+    json_accumulator: List[Any],
+) -> None:
+    """Format and emit query results for one file."""
+    # NDJSON mode: one JSON object per line (streaming, no accumulation)
+    if output_config.ndjson:
+        items = _convert_results(results, file_path, multi, output_config)
+        for item in items:
+            line = json.dumps(item, default=str)
+            if (
+                multi
+                and not output_config.no_filename
+                and not output_config.with_location
+            ):
+                # provenance already injected into dict; for non-dicts
+                # prefix with filename
+                if not isinstance(item, dict):
+                    line = f"{file_path}:{line}"
+            print(line, flush=True)
+        return
+
+    # JSON mode with multiple files: accumulate for merged output
+    if output_config.output_json and multi:
+        json_accumulator.extend(
+            _convert_results(results, file_path, multi, output_config)
+        )
+        return
+
+    # Single-file JSON with location
+    if output_config.with_location:
+        items = _convert_results(results, file_path, multi, output_config)
+        data = items[0] if len(items) == 1 else items
+        output = json.dumps(data, indent=output_config.json_indent, default=str)
+    else:
+        output = output_config.format_output(results)
+
+    if multi and not output_config.no_filename and not output_config.with_location:
+        prefix = f"{file_path}:"
+        print("\n".join(prefix + line for line in output.splitlines()))
+    else:
+        print(output)
+
+
+def _execute_and_emit(  # pylint: disable=too-many-branches
     args: argparse.Namespace,
     query: str,
     optional: bool,
@@ -786,45 +833,9 @@ def _execute_and_emit(  # pylint: disable=too-many-branches,too-many-statements
                 print(json.dumps(describe_results(results), indent=2))
                 continue
 
-            # NDJSON mode: one JSON object per line (streaming, no accumulation)
-            if args.ndjson:
-                items = _convert_results(results, file_path, multi, output_config)
-                for item in items:
-                    line = json.dumps(item, default=str)
-                    if multi and not args.no_filename and not args.with_location:
-                        # provenance already injected into dict; for non-dicts
-                        # prefix with filename
-                        if not isinstance(item, dict):
-                            line = f"{file_path}:{line}"
-                    print(line, flush=True)
-                continue
-
-            # JSON mode with multiple files: accumulate for merged output
-            if args.json and multi:
-                json_accumulator.extend(
-                    _convert_results(results, file_path, multi, output_config)
-                )
-                continue
-
-            # Single-file JSON with location
-            if args.with_location:
-                items = _convert_results(results, file_path, multi, output_config)
-                if len(items) == 1:
-                    output = json.dumps(
-                        items[0], indent=output_config.json_indent, default=str
-                    )
-                else:
-                    output = json.dumps(
-                        items, indent=output_config.json_indent, default=str
-                    )
-            else:
-                output = output_config.format_output(results)
-
-            if multi and not args.no_filename and not args.with_location:
-                prefix = f"{file_path}:"
-                print("\n".join(prefix + line for line in output.splitlines()))
-            else:
-                print(output)
+            _emit_file_results(
+                results, file_path, multi, output_config, json_accumulator
+            )
 
     # Emit accumulated JSON results as a single merged array
     if json_accumulator:

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -1,6 +1,7 @@
 """``hq`` CLI entry point — query HCL2 files."""
 
 import argparse
+import dataclasses
 import json
 import multiprocessing
 import os
@@ -166,92 +167,6 @@ def _rawify(value: Any) -> Any:
     return value
 
 
-def _format_result(
-    result: Any,
-    output_json: bool,
-    output_value: bool,
-    json_indent: Optional[int],
-    output_raw: bool = False,
-    serialization_options: Optional[SerializationOptions] = None,
-) -> str:
-    """Format a single result for output."""
-    if output_json:
-        return json.dumps(
-            _convert_for_json(result, options=serialization_options),
-            indent=json_indent,
-            default=str,
-        )
-
-    if output_raw:
-        if isinstance(result, NodeView):
-            val = result.to_dict()
-            if isinstance(val, str):
-                return _strip_dollar_wrap(_strip_quotes(val))
-            # For dicts with a single key (e.g. attribute), extract the value
-            if isinstance(val, dict) and len(val) == 1:
-                inner = next(iter(val.values()))
-                if isinstance(inner, str):
-                    return _strip_dollar_wrap(_strip_quotes(inner))
-                return str(inner)
-            return json.dumps(_rawify(val), default=str)
-        if isinstance(result, dict):
-            return json.dumps(_rawify(result), default=str)
-        if isinstance(result, str):
-            return _strip_dollar_wrap(_strip_quotes(result))
-        return str(result)
-
-    if output_value:
-        if isinstance(result, NodeView):
-            val = result.to_dict()
-            # Auto-unwrap single-key dicts (e.g. AttributeView → inner value)
-            if isinstance(val, dict) and len(val) == 1:
-                inner = next(iter(val.values()))
-                return _strip_dollar_wrap(str(inner))
-            return _strip_dollar_wrap(str(val))
-        if isinstance(result, str):
-            return _strip_dollar_wrap(result)
-        return str(result)
-
-    # Default: HCL output
-    if isinstance(result, NodeView):
-        return result.to_hcl()
-    if isinstance(result, list):
-        return _format_list(
-            result,
-            output_json,
-            output_value,
-            json_indent,
-            output_raw,
-            serialization_options,
-        )
-    if isinstance(result, str):
-        return _strip_dollar_wrap(result)
-    return str(result)
-
-
-def _format_list(
-    items: list,
-    output_json: bool,
-    output_value: bool,
-    json_indent: Optional[int],
-    output_raw: bool = False,
-    serialization_options: Optional[SerializationOptions] = None,
-) -> str:
-    """Format a list result (e.g. from hybrid mode returning a list property)."""
-    if output_json:
-        converted = [
-            _convert_for_json(item, options=serialization_options) for item in items
-        ]
-        return json.dumps(converted, indent=json_indent, default=str)
-    parts = []
-    for item in items:
-        if isinstance(item, NodeView):
-            parts.append(item.to_hcl() if not output_value else str(item.to_dict()))
-        else:
-            parts.append(str(item))
-    return "[" + ", ".join(parts) + "]" if not output_value else "\n".join(parts)
-
-
 def _convert_for_json(
     value: Any,
     options: Optional[SerializationOptions] = None,
@@ -264,34 +179,105 @@ def _convert_for_json(
     return value
 
 
-def _format_output(
-    results: List[Any],
-    output_json: bool,
-    output_value: bool,
-    json_indent: Optional[int],
-    output_raw: bool = False,
-    serialization_options: Optional[SerializationOptions] = None,
-) -> str:
-    """Format results for final output."""
-    if output_json and len(results) > 1:
-        items = [
-            _convert_for_json(item, options=serialization_options) for item in results
-        ]
-        return json.dumps(items, indent=json_indent, default=str)
+@dataclasses.dataclass
+class OutputConfig:
+    """Output mode configuration for hq results.
 
-    parts = []
-    for result in results:
-        parts.append(
-            _format_result(
-                result,
-                output_json,
-                output_value,
-                json_indent,
-                output_raw,
-                serialization_options,
+    All fields are primitives or dataclasses, ensuring picklability
+    for ``multiprocessing.Pool`` workers.
+    """
+
+    output_json: bool = False
+    output_value: bool = False
+    output_raw: bool = False
+    json_indent: Optional[int] = None
+    ndjson: bool = False
+    with_location: bool = False
+    with_comments: bool = False
+    no_filename: bool = False
+    serialization_options: Optional[SerializationOptions] = None
+
+    def format_result(self, result: Any) -> str:
+        """Format a single result for output."""
+        if self.output_json:
+            return json.dumps(
+                _convert_for_json(result, options=self.serialization_options),
+                indent=self.json_indent,
+                default=str,
             )
-        )
-    return "\n".join(parts)
+
+        if self.output_raw:
+            if isinstance(result, NodeView):
+                val = result.to_dict()
+                if isinstance(val, str):
+                    return _strip_dollar_wrap(_strip_quotes(val))
+                # For dicts with a single key (e.g. attribute), extract the value
+                if isinstance(val, dict) and len(val) == 1:
+                    inner = next(iter(val.values()))
+                    if isinstance(inner, str):
+                        return _strip_dollar_wrap(_strip_quotes(inner))
+                    return str(inner)
+                return json.dumps(_rawify(val), default=str)
+            if isinstance(result, dict):
+                return json.dumps(_rawify(result), default=str)
+            if isinstance(result, str):
+                return _strip_dollar_wrap(_strip_quotes(result))
+            return str(result)
+
+        if self.output_value:
+            if isinstance(result, NodeView):
+                val = result.to_dict()
+                # Auto-unwrap single-key dicts (e.g. AttributeView → inner value)
+                if isinstance(val, dict) and len(val) == 1:
+                    inner = next(iter(val.values()))
+                    return _strip_dollar_wrap(str(inner))
+                return _strip_dollar_wrap(str(val))
+            if isinstance(result, str):
+                return _strip_dollar_wrap(result)
+            return str(result)
+
+        # Default: HCL output
+        if isinstance(result, NodeView):
+            return result.to_hcl()
+        if isinstance(result, list):
+            return self.format_list(result)
+        if isinstance(result, str):
+            return _strip_dollar_wrap(result)
+        return str(result)
+
+    def format_list(self, items: list) -> str:
+        """Format a list result (e.g. from hybrid mode returning a list)."""
+        if self.output_json:
+            converted = [
+                _convert_for_json(item, options=self.serialization_options)
+                for item in items
+            ]
+            return json.dumps(converted, indent=self.json_indent, default=str)
+        parts = []
+        for item in items:
+            if isinstance(item, NodeView):
+                parts.append(
+                    item.to_hcl() if not self.output_value else str(item.to_dict())
+                )
+            else:
+                parts.append(str(item))
+        if not self.output_value:
+            return "[" + ", ".join(parts) + "]"
+        return "\n".join(parts)
+
+    def format_output(self, results: List[Any]) -> str:
+        """Format results for final output."""
+        if self.output_json and len(results) > 1:
+            items = [
+                _convert_for_json(item, options=self.serialization_options)
+                for item in results
+            ]
+            return json.dumps(items, indent=self.json_indent, default=str)
+
+        parts = []
+        for result in results:
+            parts.append(self.format_result(result))
+        return "\n".join(parts)
 
 
 _EXIT_TO_ERROR_TYPE = {
@@ -485,44 +471,29 @@ def _merge_location(converted: Any, location: dict) -> Any:
 def _convert_results(
     results: List[Any],
     file_path: str,
-    with_location: bool,
     multi: bool,
-    no_filename: bool,
-    serialization_options: Optional[SerializationOptions],
+    output_config: OutputConfig,
 ) -> List[Any]:
     """Convert query results for JSON output with location/provenance metadata."""
     converted = []
     for result in results:
-        item = _convert_for_json(result, options=serialization_options)
-        if with_location:
+        item = _convert_for_json(result, options=output_config.serialization_options)
+        if output_config.with_location:
             loc = _extract_location(result, file_path)
             item = _merge_location(item, loc)
-        elif multi and not no_filename:
+        elif multi and not output_config.no_filename:
             item = _inject_provenance(item, file_path)
         converted.append(item)
     return converted
 
 
-def _process_file(args_tuple):  # pylint: disable=too-many-locals
+def _process_file(args_tuple):
     """Worker: parse, query, and convert results for one file.
 
     Returns ``(file_path, exit_code, converted_results, error_msg)``.
     All return values are picklable plain Python objects.
     """
-    (
-        file_path,
-        query,
-        is_eval,
-        raw_query,
-        with_location,
-        with_comments,
-        no_filename,
-        multi,
-        output_json,
-        ndjson,
-    ) = args_tuple
-
-    ser_opts = SerializationOptions(with_comments=True) if with_comments else None
+    file_path, query, is_eval, raw_query, multi, output_config = args_tuple
 
     try:
         with open(file_path, encoding="utf-8") as f:
@@ -545,9 +516,7 @@ def _process_file(args_tuple):  # pylint: disable=too-many-locals
     if not results:
         return (file_path, EXIT_SUCCESS, [], None)
 
-    converted = _convert_results(
-        results, file_path, with_location, multi, no_filename, ser_opts
-    )
+    converted = _convert_results(results, file_path, multi, output_config)
 
     return (file_path, EXIT_SUCCESS, converted, None)
 
@@ -683,6 +652,18 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     if args.with_comments:
         serialization_options = SerializationOptions(with_comments=True)
 
+    output_config = OutputConfig(
+        output_json=args.json,
+        output_value=args.value,
+        output_raw=output_raw,
+        json_indent=json_indent,
+        ndjson=args.ndjson,
+        with_location=args.with_location,
+        with_comments=args.with_comments,
+        no_filename=args.no_filename,
+        serialization_options=serialization_options,
+    )
+
     # --schema: dump schema and exit
     if args.schema:
         print(json.dumps(build_schema(), indent=2))
@@ -747,19 +728,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
     if use_parallel:
         n_workers = args.jobs or min(os.cpu_count() or 1, len(file_paths))
         worker_args = [
-            (
-                fp,
-                query,
-                False,  # is_eval
-                args.QUERY,
-                args.with_location,
-                args.with_comments,
-                args.no_filename,
-                multi,
-                args.json,
-                args.ndjson,
-            )
-            for fp in file_paths
+            (fp, query, False, args.QUERY, multi, output_config) for fp in file_paths
         ]
 
         with multiprocessing.Pool(n_workers) as pool:
@@ -801,14 +770,7 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
 
             # NDJSON mode: one JSON object per line (streaming, no accumulation)
             if args.ndjson:
-                items = _convert_results(
-                    results,
-                    file_path,
-                    args.with_location,
-                    multi,
-                    args.no_filename,
-                    serialization_options,
-                )
+                items = _convert_results(results, file_path, multi, output_config)
                 for item in items:
                     line = json.dumps(item, default=str)
                     if multi and not args.no_filename and not args.with_location:
@@ -822,40 +784,19 @@ def main():  # pylint: disable=too-many-branches,too-many-statements
             # JSON mode with multiple files: accumulate for merged output
             if args.json and multi:
                 json_accumulator.extend(
-                    _convert_results(
-                        results,
-                        file_path,
-                        args.with_location,
-                        multi,
-                        args.no_filename,
-                        serialization_options,
-                    )
+                    _convert_results(results, file_path, multi, output_config)
                 )
                 continue
 
             # Single-file JSON with location
             if args.with_location:
-                items = _convert_results(
-                    results,
-                    file_path,
-                    True,
-                    multi,
-                    args.no_filename,
-                    serialization_options,
-                )
+                items = _convert_results(results, file_path, multi, output_config)
                 if len(items) == 1:
                     output = json.dumps(items[0], indent=json_indent, default=str)
                 else:
                     output = json.dumps(items, indent=json_indent, default=str)
             else:
-                output = _format_output(
-                    results,
-                    args.json,
-                    args.value,
-                    json_indent,
-                    output_raw,
-                    serialization_options,
-                )
+                output = output_config.format_output(results)
 
             if multi and not args.no_filename and not args.with_location:
                 prefix = f"{file_path}:"

--- a/hcl2/query/attributes.py
+++ b/hcl2/query/attributes.py
@@ -1,14 +1,24 @@
 """AttributeView facade."""
 
-from typing import Any
+from typing import Any, List, Optional
 
 from hcl2.query._base import NodeView, register_view, view_for
+from hcl2.rules.abstract import LarkElement
 from hcl2.rules.base import AttributeRule
+from hcl2.utils import SerializationOptions
 
 
 @register_view(AttributeRule)
 class AttributeView(NodeView):
     """View over an HCL2 attribute (AttributeRule)."""
+
+    def __init__(
+        self,
+        node: LarkElement,
+        adjacent_comments: Optional[List[dict]] = None,
+    ):
+        super().__init__(node)
+        self._adjacent_comments = adjacent_comments
 
     @property
     def name(self) -> str:
@@ -27,3 +37,15 @@ class AttributeView(NodeView):
         """Return a view over the expression node."""
         node: AttributeRule = self._node  # type: ignore[assignment]
         return view_for(node.expression)
+
+    def to_dict(self, options: Optional[SerializationOptions] = None) -> Any:
+        """Serialize, merging adjacent comments from the parent body."""
+        result = super().to_dict(options=options)
+        if (
+            self._adjacent_comments
+            and options is not None
+            and options.with_comments
+            and isinstance(result, dict)
+        ):
+            result["__comments__"] = self._adjacent_comments
+        return result

--- a/hcl2/query/blocks.py
+++ b/hcl2/query/blocks.py
@@ -1,11 +1,14 @@
 """BlockView facade."""
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
+from hcl2.const import COMMENTS_KEY
 from hcl2.query._base import NodeView, register_view
+from hcl2.rules.abstract import LarkElement
 from hcl2.rules.base import BlockRule
 from hcl2.rules.literal_rules import IdentifierRule
 from hcl2.rules.strings import StringRule
+from hcl2.utils import SerializationOptions
 
 
 def _label_to_str(label) -> str:
@@ -24,6 +27,14 @@ def _label_to_str(label) -> str:
 @register_view(BlockRule)
 class BlockView(NodeView):
     """View over an HCL2 block (BlockRule)."""
+
+    def __init__(
+        self,
+        node: LarkElement,
+        adjacent_comments: Optional[List[dict]] = None,
+    ):
+        super().__init__(node)
+        self._adjacent_comments = adjacent_comments
 
     @property
     def block_type(self) -> str:
@@ -49,6 +60,21 @@ class BlockView(NodeView):
 
         node: BlockRule = self._node  # type: ignore[assignment]
         return BodyView(node.body)
+
+    def to_dict(self, options: Optional[SerializationOptions] = None) -> Any:
+        """Serialize, merging adjacent comments from the parent body."""
+        result = super().to_dict(options=options)
+        if (
+            self._adjacent_comments
+            and options is not None
+            and options.with_comments
+            and isinstance(result, dict)
+        ):
+            # Place adjacent comments at the outer level of the block dict,
+            # alongside the label keys — not drilled into the body dict.
+            existing = result.get(COMMENTS_KEY, [])
+            result[COMMENTS_KEY] = self._adjacent_comments + existing
+        return result
 
     def blocks(
         self, block_type: Optional[str] = None, *labels: str

--- a/hcl2/query/body.py
+++ b/hcl2/query/body.py
@@ -4,6 +4,32 @@ from typing import List, Optional
 
 from hcl2.query._base import NodeView, register_view
 from hcl2.rules.base import AttributeRule, BlockRule, BodyRule, StartRule
+from hcl2.rules.whitespace import NewLineOrCommentRule
+
+
+def _collect_leading_comments(body: BodyRule, child_index: int) -> List[dict]:
+    """Collect comments from NewLineOrCommentRule siblings preceding *child_index*.
+
+    Walks backward through ``body.children`` from ``child_index - 1``,
+    collecting comment dicts via ``to_list()``, stopping at the first
+    ``BlockRule`` or ``AttributeRule`` (the previous semantic sibling) or
+    the start of the children list.
+    """
+    chunks: List[List[dict]] = []
+    for i in range(child_index - 1, -1, -1):
+        sibling = body.children[i]
+        if isinstance(sibling, (BlockRule, AttributeRule)):
+            break
+        if isinstance(sibling, NewLineOrCommentRule):
+            comments = sibling.to_list()
+            if comments:
+                chunks.append(comments)
+    # Reverse node order (walked backward) but keep each node's comments in order
+    chunks.reverse()
+    result: List[dict] = []
+    for chunk in chunks:
+        result.extend(chunk)
+    return result
 
 
 @register_view(StartRule)
@@ -63,7 +89,8 @@ class BodyView(NodeView):
         for child in node.children:
             if not isinstance(child, BlockRule):
                 continue
-            block_view = BlockView(child)
+            adjacent = _collect_leading_comments(node, child.index) or None
+            block_view = BlockView(child, adjacent_comments=adjacent)
             if block_type is not None and block_view.block_type != block_type:
                 continue
             if labels:
@@ -84,7 +111,8 @@ class BodyView(NodeView):
         for child in node.children:
             if not isinstance(child, AttributeRule):
                 continue
-            attr_view = AttributeView(child)
+            adjacent = _collect_leading_comments(node, child.index) or None
+            attr_view = AttributeView(child, adjacent_comments=adjacent)
             if name is not None and attr_view.name != name:
                 continue
             results.append(attr_view)

--- a/hcl2/query/pipeline.py
+++ b/hcl2/query/pipeline.py
@@ -149,6 +149,8 @@ def classify_stage(stage_str: str) -> Any:
 
     # Allow jq-style leading dot (e.g. ".foo" in a pipe stage)
     path_str = stripped
+    if path_str == ".":
+        return PathStage(segments=[])
     if path_str.startswith(".") and len(path_str) > 1 and path_str[1] != ".":
         path_str = path_str[1:]
 

--- a/hcl2/rules/base.py
+++ b/hcl2/rules/base.py
@@ -85,8 +85,8 @@ class BodyRule(LarkRule):
                 attribute_names.add(child.identifier.serialize(options))
                 result.update(child.serialize(options))
                 if options.with_comments:
-                    # collect in-line comments from attribute assignments, expressions etc
                     inline_comments.extend(child.expression.inline_comments())
+                    comments.extend(child.expression.absorbed_comments())
 
             if isinstance(child, NewLineOrCommentRule) and options.with_comments:
                 child_comments = child.to_list()

--- a/hcl2/rules/expressions.py
+++ b/hcl2/rules/expressions.py
@@ -242,6 +242,38 @@ class BinaryOpRule(ExpressionRule):
         """Return the binary term (operator + right-hand operand)."""
         return self._children[1]
 
+    @property
+    def _trailing_nl(self) -> Optional[NewLineOrCommentRule]:
+        """Return the trailing new_line_or_comment child, if present."""
+        child = self._children[2]
+        if isinstance(child, NewLineOrCommentRule):
+            return child
+        return None
+
+    def inline_comments(self):
+        """Collect inline comments, excluding absorbed body-level comments."""
+        trailing = self._trailing_nl
+        result = []
+        for child in self._children:
+            if isinstance(child, NewLineOrCommentRule):
+                # Trailing NL_OR_COMMENT with a leading newline contains
+                # body-level comments absorbed by the grammar, not inline ones.
+                if child is trailing and not child.is_inline:
+                    continue
+                comments = child.to_list()
+                if comments is not None:
+                    result.extend(comments)
+            elif isinstance(child, InlineCommentMixIn):
+                result.extend(child.inline_comments())
+        return result
+
+    def absorbed_comments(self):
+        """Return body-level comments absorbed into the trailing NL_OR_COMMENT."""
+        trailing = self._trailing_nl
+        if trailing is not None and not trailing.is_inline:
+            return trailing.to_list() or []
+        return []
+
     def serialize(
         self, options=SerializationOptions(), context=SerializationContext()
     ) -> Any:

--- a/hcl2/rules/whitespace.py
+++ b/hcl2/rules/whitespace.py
@@ -26,7 +26,17 @@ class NewLineOrCommentRule(TokenRule):
         self, options=SerializationOptions(), context=SerializationContext()
     ) -> Any:
         """Serialize to the raw comment/newline string."""
-        return self.token.serialize()
+        return "".join(child.serialize() for child in self._children)
+
+    @property
+    def is_inline(self) -> bool:
+        """True if this comment is on the same line as preceding code.
+
+        A raw string starting with ``\\n`` means the comment sits on its own
+        line (standalone).  One starting with ``#``, ``//``, or ``/*`` is
+        inline — it follows code on the same line.
+        """
+        return not self.serialize().startswith("\n")
 
     def to_list(
         self, options: SerializationOptions = SerializationOptions()
@@ -91,3 +101,11 @@ class InlineCommentMixIn(LarkRule, ABC):
                 result.extend(child.inline_comments())
 
         return result
+
+    def absorbed_comments(self):
+        """Return body-level comments absorbed by grammar into this expression.
+
+        Default: empty.  ``BinaryOpRule`` overrides this because its trailing
+        ``new_line_or_comment?`` can swallow the next body-level comment.
+        """
+        return []

--- a/test/integration/specialized/comments.json
+++ b/test/integration/specialized/comments.json
@@ -1,0 +1,57 @@
+{
+  "resource": [
+    {
+      "\"aws_instance\"": {
+        "\"web\"": {
+          "ami": "\"abc-123\"",
+          "instance_type": "\"t2.micro\"",
+          "count": "${1 + 2}",
+          "tags": {
+            "Name": "\"web\"",
+            "Env": "\"prod\""
+          },
+          "enabled": "true",
+          "nested": [
+            {
+              "key": "\"value\"",
+              "__comments__": [
+                {
+                  "value": "comment inside nested block"
+                }
+              ],
+              "__is_block__": true
+            }
+          ],
+          "__comments__": [
+            {
+              "value": "standalone comment inside block"
+            },
+            {
+              "value": "hash standalone comment"
+            },
+            {
+              "value": "absorbed standalone after binary_op"
+            },
+            {
+              "value": "multi-line\n  block comment"
+            }
+          ],
+          "__inline_comments__": [
+            {
+              "value": "comment inside object"
+            },
+            {
+              "value": "inline after value"
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "__comments__": [
+    {
+      "value": "top-level standalone comment"
+    }
+  ]
+}

--- a/test/integration/specialized/comments.tf
+++ b/test/integration/specialized/comments.tf
@@ -1,0 +1,28 @@
+// top-level standalone comment
+resource "aws_instance" "web" {
+  ami = "abc-123"
+
+  // standalone comment inside block
+  instance_type = "t2.micro"
+
+  # hash standalone comment
+  count = 1 + 2
+  # absorbed standalone after binary_op
+
+  tags = {
+    Name = "web"
+    # comment inside object
+    Env  = "prod" # inline after value
+  }
+
+  /*
+  multi-line
+  block comment
+  */
+  enabled = true
+
+  nested {
+    // comment inside nested block
+    key = "value"
+  }
+}

--- a/test/integration/test_specialized.py
+++ b/test/integration/test_specialized.py
@@ -150,6 +150,86 @@ class TestTemplateDirectives(TestCase):
         self.assertEqual(reserialized, serialized)
 
 
+class TestCommentSerialization(TestCase):
+    """Test that comments are correctly classified during HCL → JSON serialization.
+
+    Covers:
+    - Standalone comments (// and #) at body level → __comments__
+    - Standalone comments absorbed by binary_op grammar → __comments__
+    - Comments inside expressions (objects) → __inline_comments__
+    - Multi-line block comments → __comments__
+    - Comments in nested blocks
+    - Top-level comments
+    """
+
+    maxDiff = None
+    _OPTIONS = SerializationOptions(with_comments=True)
+
+    def test_comment_classification(self):
+        hcl_path = SPECIAL_DIR / "comments.tf"
+        json_path = SPECIAL_DIR / "comments.json"
+
+        actual = _parse_and_serialize(hcl_path.read_text(), options=self._OPTIONS)
+        expected = json.loads(json_path.read_text())
+
+        self.assertEqual(actual, expected)
+
+    def test_top_level_comments(self):
+        actual = _parse_and_serialize("// file header\nx = 1\n", options=self._OPTIONS)
+        self.assertEqual(actual["__comments__"], [{"value": "file header"}])
+
+    def test_standalone_in_body(self):
+        actual = _parse_and_serialize(
+            'resource "a" "b" {\n  # standalone\n  x = 1\n}\n',
+            options=self._OPTIONS,
+        )
+        block = actual["resource"][0]['"a"']['"b"']
+        self.assertEqual(block["__comments__"], [{"value": "standalone"}])
+        self.assertNotIn("__inline_comments__", block)
+
+    def test_absorbed_after_binary_op(self):
+        actual = _parse_and_serialize(
+            "x {\n  a = 1 + 2\n  # absorbed\n  b = 3\n}\n",
+            options=self._OPTIONS,
+        )
+        block = actual["x"][0]
+        self.assertIn({"value": "absorbed"}, block["__comments__"])
+        self.assertNotIn("__inline_comments__", block)
+
+    def test_inline_after_binary_op(self):
+        actual = _parse_and_serialize(
+            "x {\n  a = 1 + 2 # inline\n  b = 3\n}\n",
+            options=self._OPTIONS,
+        )
+        block = actual["x"][0]
+        self.assertEqual(block["__inline_comments__"], [{"value": "inline"}])
+
+    def test_comment_inside_object(self):
+        actual = _parse_and_serialize(
+            "x {\n  m = {\n    # inside\n    k = 1\n  }\n}\n",
+            options=self._OPTIONS,
+        )
+        block = actual["x"][0]
+        self.assertEqual(block["__inline_comments__"], [{"value": "inside"}])
+        self.assertNotIn("__comments__", block)
+
+    def test_multiline_block_comment(self):
+        actual = _parse_and_serialize(
+            "x {\n  /*\n  multi\n  line\n  */\n  a = 1\n}\n",
+            options=self._OPTIONS,
+        )
+        block = actual["x"][0]
+        self.assertEqual(block["__comments__"], [{"value": "multi\n  line"}])
+
+    def test_no_comments_without_option(self):
+        actual = _parse_and_serialize(
+            "// comment\nx = 1\n",
+            options=SerializationOptions(with_comments=False),
+        )
+        self.assertNotIn("__comments__", actual)
+        self.assertNotIn("__inline_comments__", actual)
+
+
 class TestHeredocs(TestCase):
     """Test heredoc serialization, flattening, restoration, and round-trips.
 

--- a/test/unit/cli/test_hq.py
+++ b/test/unit/cli/test_hq.py
@@ -12,6 +12,7 @@ from cli.hq import (
     EXIT_PARSE_ERROR,
     EXIT_QUERY_ERROR,
     EXIT_SUCCESS,
+    OutputConfig,
     _dispatch_query,
     _expand_file_args,
     _normalize_eval_expr,
@@ -904,7 +905,7 @@ class TestProcessFile(TestCase):
             f.write("x = 1\n")
             f.flush()
             try:
-                args = (f.name, "x", False, "x", False, False, False, True, True, False)
+                args = (f.name, "x", False, "x", True, OutputConfig(output_json=True))
                 _fp, code, converted, err = _process_file(args)
                 self.assertEqual(code, EXIT_SUCCESS)
                 self.assertIsNone(err)
@@ -919,12 +920,8 @@ class TestProcessFile(TestCase):
             "x",
             False,
             "x",
-            False,
-            False,
-            False,
             True,
-            True,
-            False,
+            OutputConfig(output_json=True),
         )
         _fp, code, _converted, err = _process_file(args)
         self.assertEqual(code, EXIT_IO_ERROR)
@@ -936,18 +933,7 @@ class TestProcessFile(TestCase):
             f.write("{invalid\n")
             f.flush()
             try:
-                args = (
-                    f.name,
-                    "x",
-                    False,
-                    "x",
-                    False,
-                    False,
-                    False,
-                    True,
-                    True,
-                    False,
-                )
+                args = (f.name, "x", False, "x", True, OutputConfig(output_json=True))
                 _fp, code, _converted, err = _process_file(args)
                 self.assertEqual(code, EXIT_PARSE_ERROR)
                 self.assertIsNotNone(err)
@@ -964,12 +950,8 @@ class TestProcessFile(TestCase):
                     "nonexistent",
                     False,
                     "nonexistent",
-                    False,
-                    False,
-                    False,
                     True,
-                    True,
-                    False,
+                    OutputConfig(output_json=True),
                 )
                 _fp, code, converted, err = _process_file(args)
                 self.assertEqual(code, EXIT_SUCCESS)

--- a/test/unit/query/test_attributes.py
+++ b/test/unit/query/test_attributes.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 
 from hcl2.query.body import DocumentView
+from hcl2.utils import SerializationOptions
 
 
 class TestAttributeView(TestCase):
@@ -38,3 +39,27 @@ class TestAttributeView(TestCase):
         attr = doc.attribute("x")
         result = attr.to_dict()
         self.assertEqual(result, {"x": 42})
+
+
+class TestAttributeViewAdjacentComments(TestCase):
+    """Tests for adjacent comment merging in AttributeView.to_dict()."""
+
+    _OPTS = SerializationOptions(with_comments=True)
+
+    def test_adjacent_comment(self):
+        doc = DocumentView.parse("# about x\nx = 1\n")
+        attr = doc.body.attributes("x")[0]
+        result = attr.to_dict(options=self._OPTS)
+        self.assertEqual(result["__comments__"], [{"value": "about x"}])
+
+    def test_no_comments_without_option(self):
+        doc = DocumentView.parse("# about x\nx = 1\n")
+        attr = doc.body.attributes("x")[0]
+        result = attr.to_dict()
+        self.assertNotIn("__comments__", result)
+
+    def test_no_adjacent_comments(self):
+        doc = DocumentView.parse("x = 1\n")
+        attr = doc.body.attributes("x")[0]
+        result = attr.to_dict(options=self._OPTS)
+        self.assertNotIn("__comments__", result)

--- a/test/unit/query/test_blocks.py
+++ b/test/unit/query/test_blocks.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 
 from hcl2.query.body import DocumentView
+from hcl2.utils import SerializationOptions
 
 
 class TestBlockView(TestCase):
@@ -65,3 +66,59 @@ class TestBlockView(TestCase):
         attrs = block.attributes("a")
         self.assertEqual(len(attrs), 1)
         self.assertEqual(attrs[0].name, "a")
+
+
+class TestBlockViewAdjacentComments(TestCase):
+    """Tests for adjacent comment merging in BlockView.to_dict()."""
+
+    _OPTS = SerializationOptions(with_comments=True)
+
+    def test_adjacent_comments_at_outer_level(self):
+        doc = DocumentView.parse(
+            '# about resource\nresource "type" "name" {\n  x = 1\n}\n'
+        )
+        block = doc.blocks("resource")[0]
+        result = block.to_dict(options=self._OPTS)
+        # Adjacent comments go at outer level, alongside the label key
+        self.assertEqual(result["__comments__"], [{"value": "about resource"}])
+        self.assertNotIn("__comments__", result['"type"']['"name"'])
+
+    def test_adjacent_separate_from_inner_comments(self):
+        doc = DocumentView.parse(
+            '# adjacent\nresource "type" "name" {\n  # inner\n  x = 1\n}\n'
+        )
+        block = doc.blocks("resource")[0]
+        result = block.to_dict(options=self._OPTS)
+        # Adjacent at outer level
+        self.assertEqual(result["__comments__"], [{"value": "adjacent"}])
+        # Inner stays in body dict under __comments__
+        body = result['"type"']['"name"']
+        self.assertEqual(body["__comments__"], [{"value": "inner"}])
+
+    def test_no_comments_without_option(self):
+        doc = DocumentView.parse('# about\nresource "type" "name" {}\n')
+        block = doc.blocks("resource")[0]
+        result = block.to_dict()
+        self.assertNotIn("__comments__", result)
+
+    def test_no_labels_block_merges_adjacent_and_inner(self):
+        doc = DocumentView.parse("# about locals\nlocals {\n  # inner\n  x = 1\n}\n")
+        block = doc.blocks("locals")[0]
+        result = block.to_dict(options=self._OPTS)
+        # No name labels -> body dict IS the top level, so they merge
+        self.assertEqual(
+            result["__comments__"],
+            [{"value": "about locals"}, {"value": "inner"}],
+        )
+
+    def test_single_label_block(self):
+        doc = DocumentView.parse('# about var\nvariable "name" {\n  default = 1\n}\n')
+        block = doc.blocks("variable")[0]
+        result = block.to_dict(options=self._OPTS)
+        self.assertEqual(result["__comments__"], [{"value": "about var"}])
+
+    def test_no_adjacent_comments(self):
+        doc = DocumentView.parse('resource "type" "name" {\n  x = 1\n}\n')
+        block = doc.blocks("resource")[0]
+        result = block.to_dict(options=self._OPTS)
+        self.assertNotIn("__comments__", result)

--- a/test/unit/query/test_body.py
+++ b/test/unit/query/test_body.py
@@ -1,7 +1,7 @@
 # pylint: disable=C0103,C0114,C0115,C0116
 from unittest import TestCase
 
-from hcl2.query.body import DocumentView, BodyView
+from hcl2.query.body import DocumentView, BodyView, _collect_leading_comments
 
 
 class TestDocumentView(TestCase):
@@ -94,3 +94,82 @@ class TestBodyView(TestCase):
         body = doc.body
         attrs = body.attributes()
         self.assertEqual(len(attrs), 2)
+
+
+class TestCollectLeadingComments(TestCase):
+    """Tests for _collect_leading_comments helper."""
+
+    def _body(self, hcl: str):
+        doc = DocumentView.parse(hcl)
+        return doc.body.raw  # BodyRule
+
+    def test_comment_before_block(self):
+        body = self._body('# about resource\nresource "a" "b" {}\n')
+        # Find the BlockRule child
+        from hcl2.rules.base import BlockRule
+
+        for child in body.children:
+            if isinstance(child, BlockRule):
+                result = _collect_leading_comments(body, child.index)
+                self.assertEqual(result, [{"value": "about resource"}])
+                return
+        self.fail("No BlockRule found")
+
+    def test_comment_before_attribute(self):
+        body = self._body("# about x\nx = 1\n")
+        from hcl2.rules.base import AttributeRule
+
+        for child in body.children:
+            if isinstance(child, AttributeRule):
+                result = _collect_leading_comments(body, child.index)
+                self.assertEqual(result, [{"value": "about x"}])
+                return
+        self.fail("No AttributeRule found")
+
+    def test_stops_at_previous_semantic_sibling(self):
+        body = self._body("x = 1\n# about y\ny = 2\n")
+        from hcl2.rules.base import AttributeRule
+
+        attrs = [c for c in body.children if isinstance(c, AttributeRule)]
+        # First attribute (x) — comment before it is empty (only bare newlines)
+        result_x = _collect_leading_comments(body, attrs[0].index)
+        self.assertEqual(result_x, [])
+        # Second attribute (y) — has "about y" above it
+        result_y = _collect_leading_comments(body, attrs[1].index)
+        self.assertEqual(result_y, [{"value": "about y"}])
+
+    def test_bare_newlines_not_collected(self):
+        body = self._body("\n\nx = 1\n")
+        from hcl2.rules.base import AttributeRule
+
+        for child in body.children:
+            if isinstance(child, AttributeRule):
+                result = _collect_leading_comments(body, child.index)
+                self.assertEqual(result, [])
+                return
+        self.fail("No AttributeRule found")
+
+    def test_multiple_comments_in_order(self):
+        body = self._body("# first\n# second\nx = 1\n")
+        from hcl2.rules.base import AttributeRule
+
+        for child in body.children:
+            if isinstance(child, AttributeRule):
+                result = _collect_leading_comments(body, child.index)
+                self.assertEqual(result, [{"value": "first"}, {"value": "second"}])
+                return
+        self.fail("No AttributeRule found")
+
+    def test_comment_between_two_blocks(self):
+        body = self._body('resource "a" "b" {}\n# about variable\nvariable "c" {}\n')
+        from hcl2.rules.base import BlockRule
+
+        blocks = [c for c in body.children if isinstance(c, BlockRule)]
+        self.assertEqual(len(blocks), 2)
+        # First block: no leading comments
+        self.assertEqual(_collect_leading_comments(body, blocks[0].index), [])
+        # Second block: "about variable"
+        self.assertEqual(
+            _collect_leading_comments(body, blocks[1].index),
+            [{"value": "about variable"}],
+        )


### PR DESCRIPTION
## Summary

The `hq` CLI module (`cli/hq.py`) had grown to ~900 lines with a 294-line `main()`, duplicated result-conversion logic across multiple code paths, and 5-6 formatting parameters threaded through every function. This PR incrementally decomposes and reorganizes the module into well-separated sections with clear responsibilities.

## Changes

- Extract `_convert_results()` to unify result-conversion + location/provenance injection that was duplicated across `_process_file` and three serial paths
- Introduce `OutputConfig` dataclass to replace 5-6 formatting parameters threaded through `_format_result`, `_format_list`, and `_format_output`; simplifies the `_process_file` worker tuple from 10 to 6 elements
- Decompose `main()` into named phases (`_build_parser`, `_validate_and_configure`, `_resolve_query`, `_execute_and_emit`), reducing it to 6 lines of orchestration
- Extract `_emit_file_results` from `_execute_and_emit` to isolate per-file output formatting
- Introduce `OutputSink` context manager to own the output lifecycle (stream/accumulate/flush), reorganize all definitions into dependency-ordered sections, deduplicate file reading via `_read_input`, and remove dead code

## Manual testing checklist

- [x] `hq 'resource' test/integration/hcl2_original/backends.tf` — basic structural query still works
- [x] `hq --json 'resource' test/integration/hcl2_original/` — JSON + multi-file output
- [x] `echo 'x = 1' | hq '.'` — stdin piping
- [x] `hq --raw '.resource' test/integration/hcl2_original/backends.tf` — raw output mode
- [x] `python -m unittest test.unit.cli.test_hq -v` — unit tests pass

---

🤖 Co-Authored-By: Claude Opus 4.6 (1M context) [Claude Code](https://claude.com/claude-code)