### PR TITLE
Prepare v8.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## \[Unreleased\]
 
+- Nothing yet.
+
+## \[8.1.1\] - 2026-04-07
+
 ### Added
 
 - v7-to-v8 migration guide and absolute GitHub links in README docs table. ([#287](https://github.com/amplify-education/python-hcl2/pull/287))


### PR DESCRIPTION
## Summary

Move unreleased changelog entries into a new `[8.1.1] - 2026-04-07` section and reset `[Unreleased]` to placeholder, in preparation for the v8.1.1 release.

## Changes

- Moved the v7-to-v8 migration guide entry from `[Unreleased]` into `[8.1.1] - 2026-04-07`
- Reset `[Unreleased]` section to "Nothing yet."

## Manual testing checklist

- [x] Verify CHANGELOG.md formatting looks correct
- [x] Confirm no entries were lost or duplicated

---

🤖 Co-Authored-By: Claude Opus 4.6 (1M context) [Claude Code](https://claude.com/claude-code)