### PR TITLE
ci: install tox-gh-actions so each matrix job runs only its own env

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install --upgrade "tox>=4.0.9,<5" build
+        run: python -m pip install --upgrade "tox>=4.0.9,<5" tox-gh-actions build
       - name: Build to generate the version file
         run: python3 -m build
       - name: Test with Tox


### PR DESCRIPTION
## Summary
- `tox.ini` has always had a `[gh-actions]` block mapping each Python version to its own `pyNN-unit` env, but the `tox-gh-actions` plugin that activates it was never installed in `pr_check.yml` — so plain `tox` tried to run *every* env in `envlist` on every matrix job, regardless of which single interpreter `actions/setup-python` had installed for that job.
- This was silently masked as long as `tox` treated a missing interpreter as a `SKIP`. The workflow's unpinned `tox>=4.0.9,<5` install recently resolved `4.56.4` (up from `4.53.0` on the last green run), and that version bump flips a missing interpreter into a hard `FAIL` — breaking every matrix job except whichever Python version(s) happen to already be on the runner's `PATH`. Confirmed via `git show <ruff-migration-commit> --stat`: that PR's diff touches neither `tox.ini` nor `pr_check.yml`, so this is a pre-existing, unrelated regression, not something introduced by the ruff migration.
- Fix: install `tox-gh-actions` alongside `tox` in the workflow so the existing `[gh-actions]` mapping actually takes effect, scoping each job to just its own env.

## Verification
- Reproduced locally: built a throwaway venv with `tox==4.56.4` (matching CI) and no `tox-gh-actions` — `tox` failed on every env whose interpreter wasn't present locally (`py38`, `py310`), exactly matching the CI failure signature (`could not find python interpreter matching any of the specs`).
- Installed `tox-gh-actions` into that venv and reran under `GITHUB_ACTIONS=true`: with a Python 3.13 interpreter, `tox` now runs only `py313-unit` and passes; repeated with a Python 3.11 venv, `tox` runs only `py311-unit` and passes. This matches exactly what each CI matrix job needs.

## Test plan
- [x] Reproduced the CI failure locally with pinned `tox==4.56.4`.
- [x] Verified the fix scopes `tox` to a single env under both Python 3.11 and 3.13, matching the CI matrix's per-job behavior.
- [x] CI green on this PR (all 6 matrix jobs: 3.8–3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)