### PR TITLE
Clean up vestigial mypy/type-stub deps now covered by additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,6 @@ repos:
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991    # Use the sha / tag you want to point at
+    rev: v1.19.1    # Use the sha / tag you want to point at
     hooks:
       - id: mypy
-        # Pinned so the hook's own venv can build typed-ast, which has no
-        # wheel for Python 3.12+; this only affects mypy's own interpreter,
-        # not the --python-version it type-checks against.
-        language_version: python3.11

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,4 @@
 -r requirements.txt
-# Linting tools
-mypy
 # Testing tools
 nose2[coverage_plugin]>=0.12,<1
 mock>=1.0.1,<2


### PR DESCRIPTION
Mechanical cleanup: these repos already run mypy via the `pre-commit/mirrors-mypy`
hook, but still carried a vestigial `mypy` pin (and in some cases boto3 type-stub
packages) in requirements/test-requirements files left over from before that hook
existed. Per [eng-guidance:pre-commit](https://eng-guidance-mcp-devops.devops.amplify.com/guidance/pre-commit),
type stubs belong in the hook's `additional_dependencies`, not requirements files.

Changes:
- Remove the dead `mypy` pin (the hook installs its own pinned mypy into an isolated venv)
- Move `types-*`/`mypy-boto3-*`/`boto3-stubs` packages into `additional_dependencies`, deduped against what was already declared there
- `python-hcl2` only: bump the mirrors-mypy rev off a pre-v1.0 pin and drop the accompanying `language_version` workaround (the typed-ast/Python-3.12-wheel issue that pin exists for)
- `codebuild_slack_notifier` only: drop a redundant `mypy .` invocation from tox's lint testenv, now superseded by the hook

Generated with assistance from Claude Code; see the commit trailer for co-authorship.