### PR TITLE
fix: parse heredocs with an empty body (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Restore `py.typed` marker so type checkers recognize `hcl2` (and `cli`) as typed packages. ([#298](https://github.com/amplify-education/python-hcl2/issues/298))
+- Parse heredocs with an empty body again. A marker immediately followed by its closing delimiter failed to match, and the lexer then ran on to a later delimiter, silently absorbing the attributes in between. ([#309](https://github.com/amplify-education/python-hcl2/issues/309))
 
 ## \[8.1.2\] - 2026-04-10
 

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -82,8 +82,8 @@ ELLIPSIS : "..."
 COLONS: "::"
 
 // Heredocs
-HEREDOC_TEMPLATE : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)*?\n\s*(?P=heredoc)\n/
-HEREDOC_TEMPLATE_TRIM : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:.|\n)*?\n\s*(?P=heredoc_trim)\n/
+HEREDOC_TEMPLATE : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:(?:.|\n)*?\n)??\s*(?P=heredoc)\n/
+HEREDOC_TEMPLATE_TRIM : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:(?:.|\n)*?\n)??\s*(?P=heredoc_trim)\n/
 
 // Ignore whitespace (but not newlines, as they're significant in HCL)
 %ignore /[ \t]+/

--- a/test/integration/specialized/heredocs.tf
+++ b/test/integration/specialized/heredocs.tf
@@ -31,4 +31,16 @@ EOF
   json_content = <<EOF
 {"key": "value"}
 EOF
+
+  empty = <<EOF
+EOF
+
+  empty_trimmed = <<-EOF
+  EOF
+
+  blank_line_only = <<EOF
+
+EOF
+
+  after_empty = "still parsed"
 }

--- a/test/integration/specialized/heredocs_flattened.json
+++ b/test/integration/specialized/heredocs_flattened.json
@@ -8,6 +8,10 @@
       "trimmed": "\"indented1\\nindented2\"",
       "trimmed_mixed": "\"line1\\n  line2\\nline3\"",
       "json_content": "\"{\\\"key\\\": \\\"value\\\"}\"",
+      "empty": "\"\"",
+      "empty_trimmed": "\"\"",
+      "blank_line_only": "\"\"",
+      "after_empty": "\"still parsed\"",
       "__is_block__": true
     }
   ]

--- a/test/integration/specialized/heredocs_preserved.json
+++ b/test/integration/specialized/heredocs_preserved.json
@@ -8,6 +8,10 @@
       "trimmed": "\"<<-EOF\n    indented1\n    indented2\n  EOF\"",
       "trimmed_mixed": "\"<<-EOF\n    line1\n      line2\n    line3\n  EOF\"",
       "json_content": "\"<<EOF\n{\"key\": \"value\"}\nEOF\"",
+      "empty": "\"<<EOF\nEOF\"",
+      "empty_trimmed": "\"<<-EOF\n  EOF\"",
+      "blank_line_only": "\"<<EOF\n\nEOF\"",
+      "after_empty": "\"still parsed\"",
       "__is_block__": true
     }
   ]

--- a/test/integration/specialized/heredocs_restored.tf
+++ b/test/integration/specialized/heredocs_restored.tf
@@ -17,4 +17,8 @@ line1
 line3
 EOF
   json_content     = "{\"key\": \"value\"}"
+  empty            = ""
+  empty_trimmed    = ""
+  blank_line_only  = ""
+  after_empty      = "still parsed"
 }

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -332,3 +332,30 @@ class TestEmptyHeredocs(TestCase):
 
     def test_indented_closing_delimiter_still_allowed(self):
         self.assertEqual(loads("a = <<EOF\nx\n   EOF\n"), {"a": '"<<EOF\nx\n   EOF"'})
+
+    def test_two_consecutive_empty_heredocs_stay_separate(self):
+        """The tightest form of the run-on: nothing between the two markers.
+
+        Before the fix this returned a single attribute whose value spanned
+        both, with `b` absent and no exception raised.
+        """
+        source = "a = <<EOF\nEOF\nb = <<EOF\nEOF\n"
+        self.assertEqual(loads(source), {"a": '"<<EOF\nEOF"', "b": '"<<EOF\nEOF"'})
+
+    def test_empty_heredoc_before_a_different_delimiter(self):
+        """The run-on latched onto any later delimiter, not just a matching one."""
+        source = "a = <<AAA\nAAA\nb = <<BBB\nbody\nBBB\n"
+        self.assertEqual(loads(source), {"a": '"<<AAA\nAAA"', "b": '"<<BBB\nbody\nBBB"'})
+
+    def test_empty_trimmed_heredoc_with_tab_indented_delimiter(self):
+        """`\\s*` before the delimiter covers tabs, not just spaces."""
+        self.assertEqual(loads("a = <<-EOF\n\tEOF\n"), {"a": '"<<-EOF\n\tEOF"'})
+
+    def test_empty_heredoc_in_a_tuple(self):
+        self.assertEqual(loads("a = [<<EOF\nEOF\n]\n"), {"a": ['"<<EOF\nEOF"']})
+
+    def test_empty_heredoc_as_an_object_value(self):
+        self.assertEqual(loads("a = {\n  k = <<EOF\nEOF\n}\n"), {"a": {"k": '"<<EOF\nEOF"'}})
+
+    def test_empty_heredoc_as_a_function_argument(self):
+        self.assertEqual(loads("a = trimspace(<<EOF\nEOF\n)\n"), {"a": '${trimspace("<<EOF\nEOF")}'})

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -288,3 +288,47 @@ class TestQuery(TestCase):
         self.assertIsInstance(result, DocumentView)
         attr = result.attribute("x")
         self.assertIsNotNone(attr)
+
+
+class TestEmptyHeredocs(TestCase):
+    """A heredoc with no body parses, and does not swallow what follows.
+
+    The v8 grammar made the newline before the closing delimiter mandatory, so
+    a marker immediately followed by its delimiter could not match. The lexer
+    then scanned on to a later delimiter, which silently absorbed the
+    intervening attributes rather than reporting an error.
+    """
+
+    def test_empty_heredoc_parses(self):
+        self.assertEqual(loads("a = <<EOF\nEOF\n"), {"a": '"<<EOF\nEOF"'})
+
+    def test_empty_trimmed_heredoc_parses(self):
+        self.assertEqual(loads("a = <<-EOF\n  EOF\n"), {"a": '"<<-EOF\n  EOF"'})
+
+    def test_empty_heredoc_flattens_to_empty_string(self):
+        options = SerializationOptions(preserve_heredocs=False)
+        self.assertEqual(loads("a = <<EOF\nEOF\n", serialization_options=options), {"a": '""'})
+
+    def test_empty_heredoc_does_not_swallow_following_attributes(self):
+        source = "a = <<EOF\nEOF\n\nb = <<EOF\nreal body\nEOF\n\nc = 1\n"
+        self.assertEqual(
+            loads(source),
+            {"a": '"<<EOF\nEOF"', "b": '"<<EOF\nreal body\nEOF"', "c": 1},
+        )
+
+    def test_heredoc_with_a_blank_body_line_is_distinct_from_empty(self):
+        self.assertEqual(loads("a = <<EOF\n\nEOF\n"), {"a": '"<<EOF\n\nEOF"'})
+
+    def test_delimiter_must_start_its_own_line(self):
+        """A word merely ending in the delimiter does not terminate the body."""
+        self.assertEqual(loads("a = <<EOF\nsayEOF\nEOF\n"), {"a": '"<<EOF\nsayEOF\nEOF"'})
+
+    def test_body_containing_the_delimiter_as_a_prefix(self):
+        self.assertEqual(loads("a = <<EOF\nEOF_NOT\nEOF\n"), {"a": '"<<EOF\nEOF_NOT\nEOF"'})
+
+    def test_consecutive_heredocs_stay_separate(self):
+        source = "a = <<EOF\nx\nEOF\nb = <<EOF\ny\nEOF\n"
+        self.assertEqual(loads(source), {"a": '"<<EOF\nx\nEOF"', "b": '"<<EOF\ny\nEOF"'})
+
+    def test_indented_closing_delimiter_still_allowed(self):
+        self.assertEqual(loads("a = <<EOF\nx\n   EOF\n"), {"a": '"<<EOF\nx\n   EOF"'})


### PR DESCRIPTION
Fixes #309.

A heredoc with an empty body failed to parse. The v8 rewrite turned the optional newline after the opening marker into a mandatory one, so a marker immediately followed by its closing delimiter no longer matched `HEREDOC_TEMPLATE`.

### The louder half of the bug

The parse error is the *rare* case. Having failed to match at that position, the lexer scans on and matches a **later** delimiter, silently absorbing everything in between:

```python
import hcl2

hcl2.loads('''locals {
  a = <<EOF
EOF

  b = <<EOF
real body
EOF
}
''')
```

8.1.2 returns a single attribute whose value runs to the end of `b`, with `b` absent from the output. No exception. Only a file whose empty heredoc has no later delimiter to latch onto surfaces as `UnexpectedToken`.

### The fix

Make the body and its trailing newline one **lazy** optional group:

```
HEREDOC_TEMPLATE : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\n(?:(?:.|\n)*?\n)??\s*(?P=heredoc)\n/
```

Two simpler-looking patches are both wrong, which seems worth recording:

- Restoring the bare `\n?` that the rewrite dropped fixes the empty case but keeps the run-on, because the body can still stretch to a later delimiter.
- Dropping the `\n` before `\s*` fixes both of those, but then `\s*` can match nothing and a word merely *ending* in the delimiter terminates the body: `<<EOF\nsayEOF\nEOF` truncates at `sayEOF`.

The laziness is load-bearing for the same reason: a greedy `?` prefers to match a body. The delimiter still has to begin its own line, so the rule from #194 is preserved.

### Tests

`test/helpers/terraform-config/` carried an empty-heredoc fixture, added with #117 when this was fixed the first time. The v8 test reorganisation replaced that layout, and no zero-line heredoc appears anywhere in the current suite — which is why nothing caught this.

The specialized heredoc fixture now covers empty, empty-trimmed and blank-line-only heredocs, plus an attribute after them that proves the lexer stops where it should. Without the grammar change, 6 of the new tests fail. `nose2 --config tox.ini`: 1400 tests, OK. `ruff` clean.


---
*This pull request, and the investigation behind it, were produced by an AI assistant (Claude) working on behalf of the author. Every reproduction, test run and benchmark cited was executed rather than inferred, but please review with that provenance in mind.*