### PR TITLE
fix: make strip_string_quotes yield values, not broken source (#308, #310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Restore `py.typed` marker so type checkers recognize `hcl2` (and `cli`) as typed packages. ([#298](https://github.com/amplify-education/python-hcl2/issues/298))
 - `strip_string_quotes` no longer unquotes string literals nested inside expressions, which produced invalid HCL such as `${upper(x)}` from `upper("x")`. ([#310](https://github.com/amplify-education/python-hcl2/issues/310))
-- `strip_string_quotes` now resolves escape sequences, so the values it yields match what the option documents. ([#308](https://github.com/amplify-education/python-hcl2/issues/308))
+- `strip_string_quotes` now resolves escape sequences, so the values it yields match what the option documents. Escapes naming a codepoint outside the Unicode range, or a lone surrogate, are preserved verbatim rather than raising. ([#308](https://github.com/amplify-education/python-hcl2/issues/308))
 
 ## \[8.1.2\] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Restore `py.typed` marker so type checkers recognize `hcl2` (and `cli`) as typed packages. ([#298](https://github.com/amplify-education/python-hcl2/issues/298))
+- `strip_string_quotes` no longer unquotes string literals nested inside expressions, which produced invalid HCL such as `${upper(x)}` from `upper("x")`. ([#310](https://github.com/amplify-education/python-hcl2/issues/310))
+- `strip_string_quotes` now resolves escape sequences, so the values it yields match what the option documents. ([#308](https://github.com/amplify-education/python-hcl2/issues/308))
 
 ## \[8.1.2\] - 2026-04-10
 

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -77,7 +77,7 @@ data = loads(text, serialization_options=SerializationOptions(
 | `preserve_heredocs` | `bool` | `True` | Keep heredocs in their original form                                                                                                            |
 | `force_operation_parentheses` | `bool` | `False` | Force parentheses around all operations                                                                                                         |
 | `preserve_scientific_notation` | `bool` | `True` | Keep scientific notation as-is                                                                                                                  |
-| `strip_string_quotes` | `bool` | `False` | Remove surrounding quotes from string values (e.g. `"hello"` instead of `'"hello"'`). **Breaks JSON->HCL2 deserialization and reconstruction.** |
+| `strip_string_quotes` | `bool` | `False` | Yield string *values* rather than source text: remove surrounding quotes (e.g. `"hello"` instead of `'"hello"'`) and resolve escape sequences (`"a\nb"` becomes a real newline). String literals inside expressions keep their quotes, so `upper("x")` stays `'${upper("x")}'`. **Breaks JSON->HCL2 deserialization and reconstruction.** |
 
 ### Comment Format
 

--- a/docs/06_migrating_to_v8.md
+++ b/docs/06_migrating_to_v8.md
@@ -29,6 +29,10 @@ data = hcl2.load(f, serialization_options=SerializationOptions(strip_string_quot
 
 > **Note:** `strip_string_quotes=True` is one-way — dicts produced with it cannot round-trip back to HCL via `dumps()` because the quotes needed to distinguish strings from identifiers are gone.
 
+Because the option asks for values rather than source text, it also resolves the escape sequences HCL defines (`\n`, `\r`, `\t`, `\"`, `\\`, `\uNNNN`, `\UNNNNNNNN`), as v7 did. Escapes are resolved in a single pass, so `\\n` is a backslash followed by `n` rather than a newline — v7 replaced sequentially and produced a newline there. Any other escape, including a codepoint outside the Unicode range, is left verbatim.
+
+Quotes are stripped only from strings in *value* position. A string literal inside an expression is part of that expression's source text and keeps its quotes, so `upper("x")` serializes to `'${upper("x")}'` — unquoting it there would change what it refers to.
+
 ## New metadata keys in output dicts
 
 **Impact: high** — code that iterates keys or does exact-match assertions will break.

--- a/hcl2/rules/strings.py
+++ b/hcl2/rules/strings.py
@@ -118,7 +118,7 @@ class StringRule(LarkRule):
         content, so an escape inside them is not this string's to resolve.
         """
         serialized = part.serialize(options, context)
-        if isinstance(part.content, STRING_CHARS):
+        if part.content.lark_name() == "STRING_CHARS":
             return process_escape_sequences(serialized)
         return serialized
 

--- a/hcl2/rules/strings.py
+++ b/hcl2/rules/strings.py
@@ -21,6 +21,7 @@ from hcl2.utils import (
     HEREDOC_TRIM_PATTERN,
     SerializationContext,
     SerializationOptions,
+    process_escape_sequences,
     to_dollar_string,
 )
 
@@ -92,11 +93,34 @@ class StringRule(LarkRule):
         return self.children[1:-1]
 
     def serialize(self, options=SerializationOptions(), context=SerializationContext()) -> Any:
-        """Serialize to a quoted string."""
+        """Serialize to a quoted string.
+
+        `strip_string_quotes` asks for the string's value rather than its
+        source form, so it applies only where a value is what the caller gets:
+        a string nested inside an expression is part of that expression's text,
+        and unquoting it there would produce something that is no longer valid
+        HCL (`upper("x")` becoming `upper(x)`).
+        """
+        if options.strip_string_quotes and not context.inside_dollar_string:
+            return "".join(
+                self._serialize_part_as_value(part, options, context) for part in self.string_parts
+            )
+
         inner = "".join(part.serialize(options, context) for part in self.string_parts)
-        if options.strip_string_quotes:
-            return inner
         return '"' + inner + '"'
+
+    @staticmethod
+    def _serialize_part_as_value(part, options, context) -> str:
+        """Serialize one part, resolving escapes in literal text only.
+
+        Interpolations and escaped interpolation/directive markers are passed
+        through untouched: their text is expression source, not literal
+        content, so an escape inside them is not this string's to resolve.
+        """
+        serialized = part.serialize(options, context)
+        if isinstance(part.content, STRING_CHARS):
+            return process_escape_sequences(serialized)
+        return serialized
 
 
 class HeredocTemplateRule(LarkRule):

--- a/hcl2/utils.py
+++ b/hcl2/utils.py
@@ -49,15 +49,26 @@ _SIMPLE_ESCAPES = {
 }
 _UNICODE_ESCAPE_WIDTHS = {"u": 4, "U": 8}
 _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_MAX_CODEPOINT = 0x10FFFF
+_SURROGATES = range(0xD800, 0xE000)
 
 
 def _decode_unicode_escape(text: str, index: int) -> Optional[Tuple[str, int]]:
-    """Decode a \\uNNNN or \\UNNNNNNNN escape whose marker sits at `index`."""
+    """Decode a \\uNNNN or \\UNNNNNNNN escape whose marker sits at `index`.
+
+    Returns None for anything that is not a usable character, leaving the
+    caller to preserve the escape verbatim: too few digits, a non-hex digit, a
+    codepoint past the Unicode maximum (`chr` raises for those), or a lone
+    surrogate, which `chr` accepts but which cannot be encoded to UTF-8.
+    """
     width = _UNICODE_ESCAPE_WIDTHS[text[index]]
     digits = text[index + 1 : index + 1 + width]
     if len(digits) != width or any(char not in _HEX_DIGITS for char in digits):
         return None
-    return chr(int(digits, 16)), index + 1 + width
+    codepoint = int(digits, 16)
+    if codepoint > _MAX_CODEPOINT or codepoint in _SURROGATES:
+        return None
+    return chr(codepoint), index + 1 + width
 
 
 def process_escape_sequences(value: str) -> str:

--- a/hcl2/utils.py
+++ b/hcl2/utils.py
@@ -3,6 +3,7 @@
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
+from typing import Optional, Tuple
 
 HEREDOC_PATTERN = re.compile(r"<<([a-zA-Z][a-zA-Z0-9._-]+)\n([\s\S]*)\1", re.S)
 HEREDOC_TRIM_PATTERN = re.compile(r"<<-([a-zA-Z][a-zA-Z0-9._-]+)\n([\s\S]*)\1", re.S)
@@ -37,6 +38,70 @@ class SerializationOptions:
     # producing backwards-compatible output (e.g. "hello" instead of '"hello"').
     # Note: round-trip through from_dict/dumps is NOT supported WITH this option.
     strip_string_quotes: bool = False
+
+
+_SIMPLE_ESCAPES = {
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    '"': '"',
+    "\\": "\\",
+}
+_UNICODE_ESCAPE_WIDTHS = {"u": 4, "U": 8}
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _decode_unicode_escape(text: str, index: int) -> Optional[Tuple[str, int]]:
+    """Decode a \\uNNNN or \\UNNNNNNNN escape whose marker sits at `index`."""
+    width = _UNICODE_ESCAPE_WIDTHS[text[index]]
+    digits = text[index + 1 : index + 1 + width]
+    if len(digits) != width or any(char not in _HEX_DIGITS for char in digits):
+        return None
+    return chr(int(digits, 16)), index + 1 + width
+
+
+def process_escape_sequences(value: str) -> str:
+    """Resolve the escape sequences HCL defines inside a quoted template.
+
+    Used when `strip_string_quotes` is set, which asks for the *value* of a
+    string rather than its source form. Escapes are resolved in a single pass,
+    so an escaped backslash cannot combine with the character after it: `\\\\n`
+    is a backslash followed by "n", not a newline.
+
+    An unrecognized escape is preserved verbatim, backslash included. Terraform
+    rejects those outright, but the grammar here accepts them, and a serializer
+    is the wrong place to raise an error the parser did not.
+    """
+    if "\\" not in value:
+        return value
+
+    parts = []
+    index = 0
+    length = len(value)
+    while index < length:
+        char = value[index]
+        if char != "\\" or index + 1 >= length:
+            parts.append(char)
+            index += 1
+            continue
+
+        marker = value[index + 1]
+        if marker in _SIMPLE_ESCAPES:
+            parts.append(_SIMPLE_ESCAPES[marker])
+            index += 2
+            continue
+        if marker in _UNICODE_ESCAPE_WIDTHS:
+            decoded = _decode_unicode_escape(value, index + 1)
+            if decoded is not None:
+                parts.append(decoded[0])
+                index = decoded[1]
+                continue
+
+        parts.append(char)
+        parts.append(marker)
+        index += 2
+
+    return "".join(parts)
 
 
 @dataclass

--- a/test/unit/rules/test_strings.py
+++ b/test/unit/rules/test_strings.py
@@ -178,6 +178,23 @@ class TestStringRule(TestCase):
         opts = SerializationOptions(strip_string_quotes=True)
         self.assertEqual(rule.serialize(opts), "prefix:${var.name}")
 
+    def test_serialize_strip_string_quotes_inside_expression_keeps_quotes(self):
+        """A string nested in an expression is that expression's source text."""
+        rule = _make_string([_make_string_part_chars("x")])
+        opts = SerializationOptions(strip_string_quotes=True)
+        ctx = SerializationContext(inside_dollar_string=True)
+        self.assertEqual(rule.serialize(opts, ctx), '"x"')
+
+    def test_serialize_strip_string_quotes_resolves_escapes(self):
+        rule = _make_string([_make_string_part_chars(r"say \"hi\"")])
+        opts = SerializationOptions(strip_string_quotes=True)
+        self.assertEqual(rule.serialize(opts), 'say "hi"')
+
+    def test_serialize_without_strip_keeps_escapes_raw(self):
+        """Default output stays source-shaped so it can be reconstructed."""
+        rule = _make_string([_make_string_part_chars(r"say \"hi\"")])
+        self.assertEqual(rule.serialize(), r'"say \"hi\""')
+
 
 # --- HeredocTemplateRule tests ---
 

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -351,6 +351,22 @@ class TestStripStringQuotes(TestCase):
     def test_unknown_escape_is_preserved(self):
         self.assertEqual(self._load(r'a = "keep \q intact"' + "\n"), {"a": r"keep \q intact"})
 
+    def test_out_of_range_unicode_escape_does_not_raise(self):
+        """An unusable codepoint is preserved, not propagated as an exception.
+
+        `\\U00110000` makes `chr` raise ValueError and `\\UFFFFFFFF` makes it
+        raise OverflowError; neither is the serializer's error to raise, since
+        the grammar accepted the input.
+        """
+        self.assertEqual(self._load(r'a = "X\U00110000Y"' + "\n"), {"a": r"X\U00110000Y"})
+        self.assertEqual(self._load(r'a = "X\UFFFFFFFFY"' + "\n"), {"a": r"X\UFFFFFFFFY"})
+
+    def test_lone_surrogate_escape_stays_encodable(self):
+        """Decoding it would yield a value that cannot be written out as UTF-8."""
+        result = self._load(r'a = "X\uD800Y"' + "\n")
+        self.assertEqual(result, {"a": r"X\uD800Y"})
+        result["a"].encode("utf-8")
+
     def test_interpolation_is_left_alone(self):
         self.assertEqual(self._load('a = "pre${var.x}post"\n'), {"a": "pre${var.x}post"})
 

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -288,3 +288,75 @@ class TestQuery(TestCase):
         self.assertIsInstance(result, DocumentView)
         attr = result.attribute("x")
         self.assertIsNotNone(attr)
+
+
+class TestStripStringQuotes(TestCase):
+    """`strip_string_quotes=True` asks for values, not source text.
+
+    It is the documented v7-compatibility path, so it has to yield what v7
+    yielded: quotes removed from string *values*, escape sequences resolved,
+    and expressions left as valid HCL.
+    """
+
+    _OPTIONS = SerializationOptions(strip_string_quotes=True)
+
+    def _load(self, source):
+        return loads(source, serialization_options=self._OPTIONS)
+
+    def test_plain_value_loses_its_quotes(self):
+        self.assertEqual(self._load('a = "plain"\n'), {"a": "plain"})
+
+    def test_value_in_object_and_list(self):
+        self.assertEqual(
+            self._load('a = { k = "v" }\nb = ["x"]\n'),
+            {"a": {"k": "v"}, "b": ["x"]},
+        )
+
+    def test_function_argument_keeps_its_quotes(self):
+        """Unquoting here would turn a string into an identifier."""
+        self.assertEqual(self._load('a = upper("x")\n'), {"a": '${upper("x")}'})
+
+    def test_conditional_branches_keep_their_quotes(self):
+        self.assertEqual(
+            self._load('a = var.x ? "yes" : "no"\n'),
+            {"a": '${var.x ? "yes" : "no"}'},
+        )
+
+    def test_comparison_against_a_string_keeps_its_quotes(self):
+        """An unquoted empty string would leave `s != ` behind."""
+        self.assertEqual(
+            self._load('a = [for s in var.l : upper(s) if s != ""]\n'),
+            {"a": '${[for s in var.l : upper(s) if s != ""]}'},
+        )
+
+    def test_nested_call_keeps_every_quote(self):
+        self.assertEqual(
+            self._load('a = join(",", ["x", "y"])\n'),
+            {"a": '${join(",", ["x", "y"])}'},
+        )
+
+    def test_escaped_quote_is_resolved(self):
+        self.assertEqual(self._load(r'a = "quote \"in\" here"' + "\n"), {"a": 'quote "in" here'})
+
+    def test_escaped_whitespace_is_resolved(self):
+        self.assertEqual(self._load(r'a = "x\ny\tz"' + "\n"), {"a": "x\ny\tz"})
+
+    def test_escaped_backslash_is_resolved(self):
+        self.assertEqual(self._load(r'a = "back\\slash"' + "\n"), {"a": "back\\slash"})
+
+    def test_escaped_backslash_does_not_combine_with_the_next_character(self):
+        r"""`\\n` is a backslash followed by "n", not a newline."""
+        self.assertEqual(self._load(r'a = "back\\nslash"' + "\n"), {"a": "back\\nslash"})
+
+    def test_unknown_escape_is_preserved(self):
+        self.assertEqual(self._load(r'a = "keep \q intact"' + "\n"), {"a": r"keep \q intact"})
+
+    def test_interpolation_is_left_alone(self):
+        self.assertEqual(self._load('a = "pre${var.x}post"\n'), {"a": "pre${var.x}post"})
+
+    def test_escaped_interpolation_marker_is_left_alone(self):
+        self.assertEqual(self._load('a = "lit $${x}"\n'), {"a": "lit $${x}"})
+
+    def test_default_options_still_preserve_source_form(self):
+        """Without the option, the source form is kept for reconstruction."""
+        self.assertEqual(loads(r'a = "line1\nline2"' + "\n"), {"a": r'"line1\nline2"'})

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -179,3 +179,30 @@ class TestProcessEscapeSequences(TestCase):
 
     def test_trailing_backslash_is_preserved(self):
         self.assertEqual(process_escape_sequences("trailing\\"), "trailing\\")
+
+    def test_highest_valid_codepoint_is_decoded(self):
+        self.assertEqual(process_escape_sequences(r"\U0010FFFF"), "\U0010ffff")
+
+    def test_codepoint_past_the_unicode_maximum_is_preserved(self):
+        """`chr` raises above 0x10FFFF; the escape is left verbatim instead."""
+        self.assertEqual(process_escape_sequences(r"\U00110000"), r"\U00110000")
+
+    def test_codepoint_too_large_for_c_int_is_preserved(self):
+        """`int(digits, 16)` fits in a Python int but overflows `chr`."""
+        self.assertEqual(process_escape_sequences(r"\UFFFFFFFF"), r"\UFFFFFFFF")
+
+    def test_lone_surrogate_is_preserved(self):
+        r"""`chr(0xD800)` succeeds but the result cannot be encoded to UTF-8."""
+        self.assertEqual(process_escape_sequences(r"\uD800"), r"\uD800")
+        self.assertEqual(process_escape_sequences(r"\uDFFF"), r"\uDFFF")
+
+    def test_characters_bracketing_the_surrogate_range_still_decode(self):
+        """Only D800-DFFF is rejected; the codepoints either side still decode."""
+        self.assertEqual(process_escape_sequences(r"\uD7FF"), "\ud7ff")
+        self.assertEqual(process_escape_sequences(r"\uE000"), "\ue000")
+
+    def test_result_is_always_utf8_encodable(self):
+        """The point of rejecting surrogates: callers can safely write the value out."""
+        for source in (r"\uD800", r"\uDFFF", r"\U00110000", r"\UFFFFFFFF"):
+            with self.subTest(source=source):
+                process_escape_sequences(source).encode("utf-8")

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -5,6 +5,7 @@ from hcl2.utils import (
     SerializationContext,
     SerializationOptions,
     is_dollar_string,
+    process_escape_sequences,
     to_dollar_string,
     unwrap_dollar_string,
     wrap_into_parentheses,
@@ -140,3 +141,41 @@ class TestWrapIntoParentheses(TestCase):
 
     def test_dollar_expression(self):
         self.assertEqual(wrap_into_parentheses("${a + b}"), "${(a + b)}")
+
+
+class TestProcessEscapeSequences(TestCase):
+    """Escape resolution used by `strip_string_quotes`."""
+
+    def test_no_backslash_is_returned_unchanged(self):
+        self.assertEqual(process_escape_sequences("plain text"), "plain text")
+
+    def test_simple_escapes(self):
+        self.assertEqual(process_escape_sequences(r"a\nb\tc\rd"), "a\nb\tc\rd")
+
+    def test_escaped_quote(self):
+        self.assertEqual(process_escape_sequences(r"say \"hi\""), 'say "hi"')
+
+    def test_escaped_backslash(self):
+        self.assertEqual(process_escape_sequences(r"back\\slash"), "back\\slash")
+
+    def test_escaped_backslash_is_not_reused_by_the_next_character(self):
+        r"""A single pass: `\\n` cannot become a newline."""
+        self.assertEqual(process_escape_sequences(r"back\\nslash"), "back\\nslash")
+
+    def test_unicode_escape(self):
+        self.assertEqual(process_escape_sequences(r"café"), "café")
+
+    def test_long_unicode_escape(self):
+        self.assertEqual(process_escape_sequences(r"\U0001F600"), "\U0001f600")
+
+    def test_malformed_unicode_escape_is_preserved(self):
+        self.assertEqual(process_escape_sequences(r"\u12"), r"\u12")
+
+    def test_non_hex_unicode_escape_is_preserved(self):
+        self.assertEqual(process_escape_sequences(r"\uZZZZ"), r"\uZZZZ")
+
+    def test_unknown_escape_is_preserved(self):
+        self.assertEqual(process_escape_sequences(r"keep \q intact"), r"keep \q intact")
+
+    def test_trailing_backslash_is_preserved(self):
+        self.assertEqual(process_escape_sequences("trailing\\"), "trailing\\")


### PR DESCRIPTION
Fixes #310. Fixes #308.

`strip_string_quotes` is documented as returning a plain string instead of `'"hello"'`, and `docs/06_migrating_to_v8.md` presents it as the v7 compatibility path. It did neither job completely, and both defects live in the same method.

### It unquoted strings inside expressions (#310)

The option stripped every string literal, including those nested in an expression, where the surrounding text is HCL source rather than a value:

| source | before | after |
| --- | --- | --- |
| `upper("x")` | `${upper(x)}` | `${upper("x")}` |
| `var.x ? "yes" : "no"` | `${var.x ? yes : no}` | `${var.x ? "yes" : "no"}` |
| `[for s in l : s if s != ""]` | `${[for s in l : s if s != ]}` | `${[for s in l : s if s != ""]}` |

The first two silently change meaning, referring to identifiers that do not exist; the third is not parseable at all. The fix restricts stripping to strings that are values, using the `inside_dollar_string` flag the serializer already threads through expression rules.

### It left escapes unresolved (#308)

Asking for the value of `"line1\nline2"` returned a literal backslash and an `n`. v7 stripped quotes and resolved escapes in the same call; v8 did only the first half, so the option delivered neither the source form nor the value. Since it is already documented as one-way and not round-trippable, resolving escapes there costs nothing in reconstruction fidelity.

The pass is single, so an escaped backslash cannot combine with the character after it: `\\n` is a backslash followed by "n". v7 replaced sequentially and produced a backslash followed by a newline; the single pass matches what OpenTofu evaluates the same source to, so this is deliberately not bug-compatible with v7.

Only literal `STRING_CHARS` parts are processed. Interpolations and escaped interpolation markers carry expression text, whose escapes are not the string's to resolve.

### Scope

Default output is untouched — it stays source-shaped so `dumps()` can reconstruct it.

Existing coverage exercised the option only on simple values, which is why neither defect showed up. Without the source change, 10 of the new tests fail. `nose2 --config tox.ini`: 1419 tests, OK. `ruff` clean.


---
*This pull request, and the investigation behind it, were produced by an AI assistant (Claude) working on behalf of the author. Every reproduction, test run and benchmark cited was executed rather than inferred, but please review with that provenance in mind.*