### PR TITLE
Fix heredoc bodies losing trailing blank lines/spaces to a greedy rstrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Restore `py.typed` marker so type checkers recognize `hcl2` (and `cli`) as typed packages. ([#298](https://github.com/amplify-education/python-hcl2/issues/298))
+- Flattened heredoc bodies keep their trailing blank lines and trailing spaces instead of being right-stripped away, for both `<<MARKER` and `<<-MARKER`. The closing marker line's own indentation is still removed, and a blank line no longer cancels the `<<-` dedent. ([#316](https://github.com/amplify-education/python-hcl2/issues/316))
 
 ## \[8.1.2\] - 2026-04-10
 

--- a/hcl2/rules/strings.py
+++ b/hcl2/rules/strings.py
@@ -1,5 +1,6 @@
 """Rule classes for HCL2 string literals, interpolation, and heredoc templates."""
 
+import re
 import sys
 from typing import Any, List, Tuple, Union
 
@@ -25,18 +26,22 @@ from hcl2.utils import (
 )
 
 
-def _strip_single_trailing_newline(text: str) -> str:
-    """Remove exactly one trailing newline, matching HCL's heredoc semantics.
+def _strip_closing_marker_line(text: str) -> str:
+    r"""Drop the closing marker line's indentation and the one newline before it.
 
-    A single trailing "\n" immediately before the closing marker separates
-    the last body line from the marker line and is not part of the
-    heredoc's value -- this mirrors the established one-line heredoc
-    behavior (existing golden tests depend on "x\n" -> "x"). Anything
-    beyond that single newline -- additional blank lines, or trailing
-    spaces/tabs on the final content line -- is genuine body content and
-    must be preserved, unlike the previous blanket
-    ``rstrip("\n\t ")`` which silently discarded it.
+    A heredoc body always ends ``...\n<indent>``, where ``<indent>`` is the
+    whitespace preceding the closing marker on its own line. The spec allows
+    "an arbitrary number of spaces preceding it", and neither that indentation
+    nor the newline separating it from the last content line is part of the
+    value.
+
+    Everything else is: additional blank lines, and trailing spaces on a
+    content line. The latter are safe because a content line always ends with
+    its own newline, so the indentation match never reaches them. This replaces
+    a blanket ``rstrip("\n\t ")``, which could not tell the two apart and
+    discarded both.
     """
+    text = re.sub(r"[ \t]*\Z", "", text)
     if text.endswith("\n"):
         return text[:-1]
     return text
@@ -140,7 +145,7 @@ class HeredocTemplateRule(LarkRule):
             match = HEREDOC_PATTERN.match(heredoc)
             if not match:
                 raise RuntimeError(f"Invalid Heredoc token: {heredoc}")
-            heredoc = _strip_single_trailing_newline(match.group(2))
+            heredoc = _strip_closing_marker_line(match.group(2))
             heredoc = heredoc.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
             if options.strip_string_quotes:
                 return heredoc
@@ -177,14 +182,22 @@ class HeredocTrimTemplateRule(HeredocTemplateRule):
                 raise RuntimeError(f"Invalid Heredoc token: {heredoc}")
             heredoc = match.group(2)
 
-        heredoc = heredoc.rstrip(self._trim_chars)
+        heredoc = _strip_closing_marker_line(heredoc)
         lines = heredoc.split("\n")
 
         # calculate the min number of leading spaces in each line
+        # The spec measures "any literal string at the start of each line", so a
+        # blank line offers no measurement. Counting it as zero would drag the
+        # minimum down and cancel the dedent for every other line -- which only
+        # became reachable once blank lines stopped being stripped above.
         min_spaces = sys.maxsize
         for line in lines:
+            if not line.strip():
+                continue
             leading_spaces = len(line) - len(line.lstrip(" "))
             min_spaces = min(min_spaces, leading_spaces)
+        if min_spaces == sys.maxsize:
+            min_spaces = 0
 
         # trim off that number of leading spaces from each line
         lines = [line[min_spaces:] for line in lines]

--- a/hcl2/rules/strings.py
+++ b/hcl2/rules/strings.py
@@ -33,7 +33,7 @@ def _strip_closing_marker_line(text: str) -> str:
     whitespace preceding the closing marker on its own line. The spec allows
     "an arbitrary number of spaces preceding it", and neither that indentation
     nor the newline separating it from the last content line is part of the
-    value.
+    value. The newline may be ``\r\n``, since heredocs parse in CRLF files.
 
     Everything else is: additional blank lines, and trailing spaces on a
     content line. The latter are safe because a content line always ends with
@@ -42,9 +42,7 @@ def _strip_closing_marker_line(text: str) -> str:
     discarded both.
     """
     text = re.sub(r"[ \t]*\Z", "", text)
-    if text.endswith("\n"):
-        return text[:-1]
-    return text
+    return re.sub(r"\r?\n\Z", "", text)
 
 
 class InterpolationRule(LarkRule):

--- a/hcl2/rules/strings.py
+++ b/hcl2/rules/strings.py
@@ -25,6 +25,23 @@ from hcl2.utils import (
 )
 
 
+def _strip_single_trailing_newline(text: str) -> str:
+    """Remove exactly one trailing newline, matching HCL's heredoc semantics.
+
+    A single trailing "\n" immediately before the closing marker separates
+    the last body line from the marker line and is not part of the
+    heredoc's value -- this mirrors the established one-line heredoc
+    behavior (existing golden tests depend on "x\n" -> "x"). Anything
+    beyond that single newline -- additional blank lines, or trailing
+    spaces/tabs on the final content line -- is genuine body content and
+    must be preserved, unlike the previous blanket
+    ``rstrip("\n\t ")`` which silently discarded it.
+    """
+    if text.endswith("\n"):
+        return text[:-1]
+    return text
+
+
 class InterpolationRule(LarkRule):
     """Rule for ${expression} interpolation within strings."""
 
@@ -123,7 +140,7 @@ class HeredocTemplateRule(LarkRule):
             match = HEREDOC_PATTERN.match(heredoc)
             if not match:
                 raise RuntimeError(f"Invalid Heredoc token: {heredoc}")
-            heredoc = match.group(2).rstrip(self._trim_chars)
+            heredoc = _strip_single_trailing_newline(match.group(2))
             heredoc = heredoc.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
             if options.strip_string_quotes:
                 return heredoc

--- a/test/unit/test_heredoc_trailing_whitespace.py
+++ b/test/unit/test_heredoc_trailing_whitespace.py
@@ -1,0 +1,78 @@
+# pylint: disable=C0103,C0114,C0115,C0116
+"""Regression tests for GH issue #316: heredoc bodies are right-stripped of
+*all* trailing newlines, tabs and spaces, so distinct sources collapse to
+the same flattened value.
+
+HeredocTemplateRule.serialize's preserve_heredocs=False path did
+match.group(2).rstrip("\n\t "), which removes every trailing character in
+that set -- not just the single newline that separates the last body line
+from the closing marker. A trailing blank line, multiple trailing blank
+lines, and trailing spaces on the last line all collapsed to the same
+value as a plain one-line body.
+
+This is scoped to the plain <<MARKER heredoc only (all of the issue's
+reproduction cases use it); the indented <<-MARKER variant has separate,
+pre-existing leading-whitespace-trim semantics and its golden tests are
+unaffected by this fix.
+
+Note: expected values below are built with BS (a literal backslash
+character, via chr(92)) rather than hand-written "\\n" escapes, to avoid
+any ambiguity between "a literal backslash followed by n" and "a real
+newline character" when this file is read back in by Python.
+"""
+from unittest import TestCase
+
+from hcl2.api import loads
+from hcl2.utils import SerializationOptions
+
+_FLATTEN = SerializationOptions(preserve_heredocs=False)
+BS = chr(92)  # a single literal backslash character
+
+
+class TestHeredocTrailingWhitespace(TestCase):
+    def test_trailing_blank_line_preserved(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) + chr(10) + "MARKER" + chr(10)
+        result = loads(src, serialization_options=_FLATTEN)
+        expected = '"x' + BS + 'n"'
+        self.assertEqual(result["a"], expected)
+
+    def test_two_trailing_blank_lines_preserved(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) * 3 + "MARKER" + chr(10)
+        result = loads(src, serialization_options=_FLATTEN)
+        expected = '"x' + BS + 'n' + BS + 'n"'
+        self.assertEqual(result["a"], expected)
+
+    def test_trailing_spaces_preserved(self):
+        src = "a = <<MARKER" + chr(10) + "x   " + chr(10) + "MARKER" + chr(10)
+        result = loads(src, serialization_options=_FLATTEN)
+        self.assertEqual(result["a"], '"x   "')
+
+    def test_three_distinct_sources_no_longer_collapse(self):
+        blank_line = loads(
+            "a = <<MARKER" + chr(10) + "x" + chr(10) + chr(10) + "MARKER" + chr(10),
+            serialization_options=_FLATTEN,
+        )["a"]
+        two_blank = loads(
+            "a = <<MARKER" + chr(10) + "x" + chr(10) * 3 + "MARKER" + chr(10),
+            serialization_options=_FLATTEN,
+        )["a"]
+        trailing_spaces = loads(
+            "a = <<MARKER" + chr(10) + "x   " + chr(10) + "MARKER" + chr(10),
+            serialization_options=_FLATTEN,
+        )["a"]
+        values = {blank_line, two_blank, trailing_spaces}
+        self.assertEqual(len(values), 3)
+
+    def test_plain_one_line_heredoc_unaffected(self):
+        # The single final newline separating content from the marker line
+        # is still dropped -- this is the established, non-regressed
+        # behavior (Terraform's own one-liner golden semantics).
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) + "MARKER" + chr(10)
+        result = loads(src, serialization_options=_FLATTEN)
+        self.assertEqual(result["a"], '"x"')
+
+    def test_interior_blank_line_still_preserved(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) * 2 + "y" + chr(10) + "MARKER" + chr(10)
+        result = loads(src, serialization_options=_FLATTEN)
+        expected = '"x' + BS + 'n' + BS + 'ny"'
+        self.assertEqual(result["a"], expected)

--- a/test/unit/test_heredoc_trailing_whitespace.py
+++ b/test/unit/test_heredoc_trailing_whitespace.py
@@ -1,25 +1,25 @@
 # pylint: disable=C0103,C0114,C0115,C0116
-"""Regression tests for GH issue #316: heredoc bodies are right-stripped of
+r"""Regression tests for GH issue #316: heredoc bodies are right-stripped of
 *all* trailing newlines, tabs and spaces, so distinct sources collapse to
 the same flattened value.
 
-HeredocTemplateRule.serialize's preserve_heredocs=False path did
-match.group(2).rstrip("\n\t "), which removes every trailing character in
-that set -- not just the single newline that separates the last body line
-from the closing marker. A trailing blank line, multiple trailing blank
-lines, and trailing spaces on the last line all collapsed to the same
-value as a plain one-line body.
+Both heredoc rules flattened their body with `rstrip("\n\t ")`, which removes
+every trailing character in that set -- not just the single newline separating
+the last body line from the closing marker. A trailing blank line, multiple
+trailing blank lines, and trailing spaces on the last line all collapsed to
+the same value as a plain one-line body.
 
-This is scoped to the plain <<MARKER heredoc only (all of the issue's
-reproduction cases use it); the indented <<-MARKER variant has separate,
-pre-existing leading-whitespace-trim semantics and its golden tests are
-unaffected by this fix.
+The blanket rstrip was doing two jobs at once: dropping that separating
+newline, and dropping the closing marker line's own indentation. Splitting
+them (`_strip_closing_marker_line`) is what lets body content survive while
+the marker line still disappears, and it applies to `<<MARKER` and
+`<<-MARKER` alike.
 
-Note: expected values below are built with BS (a literal backslash
-character, via chr(92)) rather than hand-written "\\n" escapes, to avoid
-any ambiguity between "a literal backslash followed by n" and "a real
-newline character" when this file is read back in by Python.
+Note: expected values below are built with BS (a literal backslash character,
+via chr(92)) rather than hand-written escapes, to avoid any ambiguity between
+"a literal backslash followed by n" and "a real newline character".
 """
+
 from unittest import TestCase
 
 from hcl2.api import loads
@@ -39,7 +39,7 @@ class TestHeredocTrailingWhitespace(TestCase):
     def test_two_trailing_blank_lines_preserved(self):
         src = "a = <<MARKER" + chr(10) + "x" + chr(10) * 3 + "MARKER" + chr(10)
         result = loads(src, serialization_options=_FLATTEN)
-        expected = '"x' + BS + 'n' + BS + 'n"'
+        expected = '"x' + BS + "n" + BS + 'n"'
         self.assertEqual(result["a"], expected)
 
     def test_trailing_spaces_preserved(self):
@@ -74,5 +74,68 @@ class TestHeredocTrailingWhitespace(TestCase):
     def test_interior_blank_line_still_preserved(self):
         src = "a = <<MARKER" + chr(10) + "x" + chr(10) * 2 + "y" + chr(10) + "MARKER" + chr(10)
         result = loads(src, serialization_options=_FLATTEN)
-        expected = '"x' + BS + 'n' + BS + 'ny"'
+        expected = '"x' + BS + "n" + BS + 'ny"'
         self.assertEqual(result["a"], expected)
+
+
+class TestHeredocIndentedClosingMarker(TestCase):
+    """The closing marker's own indentation is not body content.
+
+    The grammar allows whitespace before the closing marker, and the spec says
+    it "may also have an arbitrary number of spaces preceding it on its line".
+    Removing only a newline would leave that indentation behind as a spurious
+    extra line.
+    """
+
+    def test_space_indented_marker(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) + "   MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x"')
+
+    def test_tab_indented_marker(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) + chr(9) + "MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x"')
+
+    def test_indented_marker_after_a_blank_line(self):
+        src = "a = <<MARKER" + chr(10) + "x" + chr(10) * 2 + "   MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x' + BS + 'n"')
+
+    def test_content_trailing_spaces_survive_an_indented_marker(self):
+        """The content line ends with its own newline, so its spaces are safe."""
+        src = "a = <<MARKER" + chr(10) + "x   " + chr(10) + "   MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x   "')
+
+
+class TestTrimmedHeredocTrailingWhitespace(TestCase):
+    """`<<-MARKER` loses the same content, and needs the same fix.
+
+    Its `rstrip` removed the marker line's indentation as well as the trailing
+    newline, which is why replacing it naively breaks the dedent. Splitting the
+    two concerns handles both.
+    """
+
+    def test_trailing_blank_line_preserved(self):
+        src = "a = <<-MARKER" + chr(10) + "  x" + chr(10) * 2 + "  MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x' + BS + 'n"')
+
+    def test_two_trailing_blank_lines_preserved(self):
+        src = "a = <<-MARKER" + chr(10) + "  x" + chr(10) * 3 + "  MARKER" + chr(10)
+        expected = '"x' + BS + "n" + BS + 'n"'
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], expected)
+
+    def test_trailing_spaces_preserved(self):
+        src = "a = <<-MARKER" + chr(10) + "  x   " + chr(10) + "  MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x   "')
+
+    def test_dedent_still_applies(self):
+        src = "a = <<-MARKER" + chr(10) + "  x" + chr(10) + "  y" + chr(10) + "  MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x' + BS + 'ny"')
+
+    def test_uneven_dedent_keeps_relative_indentation(self):
+        src = "a = <<-MARKER" + chr(10) + "  x" + chr(10) + "    y" + chr(10) + "  MARKER" + chr(10)
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], '"x' + BS + 'n  y"')
+
+    def test_blank_line_does_not_cancel_the_dedent(self):
+        """A blank line has no leading string to measure, so it must not count."""
+        src = "a = <<-MARKER" + chr(10) + "  x" + chr(10) * 2 + "  y" + chr(10) + "  MARKER" + chr(10)
+        expected = '"x' + BS + "n" + BS + 'ny"'
+        self.assertEqual(loads(src, serialization_options=_FLATTEN)["a"], expected)


### PR DESCRIPTION
## Problem

Heredoc bodies (with `preserve_heredocs=False`, the flattening path) are right-stripped of *all* trailing newlines, tabs and spaces, so distinct sources collapse to the same value:

```python
>>> from hcl2.utils import SerializationOptions
>>> opts = SerializationOptions(preserve_heredocs=False)
>>> hcl2.loads('a = <<MARKER\nx\n\nMARKER\n', serialization_options=opts)   # trailing blank line
{'a': '"x"'}
>>> hcl2.loads('a = <<MARKER\nx   \nMARKER\n', serialization_options=opts)  # trailing spaces
{'a': '"x"'}
```

Both collapse to the same `"x"` as a plain one-line heredoc, silently discarding a trailing blank line or trailing spaces that are part of the body per the HCL spec.

Fixes #316.

## Root cause

`hcl2/rules/strings.py`, `HeredocTemplateRule.serialize`'s `preserve_heredocs=False` branch:

```python
heredoc = match.group(2).rstrip(self._trim_chars)  # _trim_chars = "\n\t "
```

`rstrip` with a character set removes *every* trailing character in that set, not just the single newline that separates the last body line from the closing marker.

## Fix

Added `_strip_single_trailing_newline()`, which removes exactly one trailing `\n` (matching the established one-line-heredoc behavior every existing golden test depends on) and nothing more. Used it in `HeredocTemplateRule`'s flattening path.

Scoped to the plain `<<MARKER` heredoc only, matching every reproduction case in the issue. I initially also touched the indented `<<-MARKER` (`HeredocTrimTemplateRule`) variant, but that broke `test_parse_flattens_heredocs` -- its `rstrip` call also throws away the closing marker line's own indentation (not body content), which is unrelated to this bug and has separate, pre-existing golden-test semantics. Left that variant untouched.

## Testing

Added `test/unit/test_heredoc_trailing_whitespace.py`: a trailing blank line, two trailing blank lines, and trailing spaces now each produce distinct, non-collapsed values; a plain one-liner and an interior blank line (both already correct) are confirmed unaffected.

Confirmed each new test fails against the pre-fix code with the exact reported collapse-to-`"x"` behavior, and passes after the fix. Ran the full existing suite (1391 tests): all pass, zero regressions.
