### PR TITLE
chore: union-merge CHANGELOG.md to stop parallel PRs conflicting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Every change adds a bullet to the same "Unreleased / Fixed" list, so parallel
+# PRs conflict on CHANGELOG.md even though they never touch the same entry.
+# The built-in union driver keeps both sides instead.
+#
+# This applies to merges and rebases performed with git. GitHub's web UI does
+# not honour .gitattributes merge drivers, so the merge button and the
+# "this branch has conflicts" banner are unaffected -- resolve locally to get
+# the benefit.
+CHANGELOG.md merge=union


### PR DESCRIPTION
## Why

Every change adds a bullet to the same `Unreleased / Fixed` list, so any two open PRs conflict on `CHANGELOG.md` even when they touch nothing else in common.

Across the five open fix PRs (#311, #312, #313, #317, #318) that accounted for **four of the seven** conflict resolutions needed to land them — more than the two real source conflicts combined. It is pure busywork: no two of those PRs ever edited the same CHANGELOG line.

## What

One line, plus a comment explaining it:

```
CHANGELOG.md merge=union
```

`union` is a built-in git merge driver, so no `merge.<driver>.driver` config is needed on anyone's machine.

## Scope — please read before expecting too much

Git honours this for **local merges and rebases**. GitHub's web UI does **not** read `.gitattributes` merge drivers, so:

- the merge button still will not auto-resolve a CHANGELOG conflict
- the "this branch has conflicts" banner is unchanged

The benefit lands when a branch is updated locally and pushed, which is how the open PRs are being brought up to date. This limitation is noted in the file itself so the next reader is not misled.

## Trade-off

If two branches genuinely edit the *same* CHANGELOG line — say both reword an existing entry — union keeps both versions rather than flagging a conflict. For an append-only list of release notes that is a good trade, but it is a real behaviour change worth knowing about.

## Test plan

Verified against a real open PR rather than a synthetic case. With this commit as the base, merging #313 drops its conflicts:

| base | conflicts when merging #313 |
|---|---|
| `main` | `CHANGELOG.md`, `test/unit/test_api.py` |
| `main` + this change | `test/unit/test_api.py` |

Also exercised earlier across all five open PRs merged in sequence: all four CHANGELOG conflicts disappeared, and the resulting `Unreleased` section contained every entry in merge order with no duplication and no leftover markers.

No code paths touched; the full suite is unaffected.
