### PR TITLE
chore: sort imports so ruff check passes on main

### DIFF
--- a/bin/terraform_test
+++ b/bin/terraform_test
@@ -13,9 +13,8 @@ Options:
 import argparse
 import os
 
-from hcl2.version import __version__
-
 from hcl2 import load
+from hcl2.version import __version__
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="This script recursively converts hcl2 files to json")

--- a/cli/hcl_to_json.py
+++ b/cli/hcl_to_json.py
@@ -6,8 +6,6 @@ import os
 import sys
 from typing import IO, List, Optional, TextIO
 
-from hcl2.version import __version__
-
 from cli.helpers import (
     EXIT_IO_ERROR,
     EXIT_PARSE_ERROR,
@@ -24,6 +22,7 @@ from cli.helpers import (
 )
 from hcl2 import load
 from hcl2.utils import SerializationOptions
+from hcl2.version import __version__
 
 _HCL_EXTENSIONS = {".tf", ".hcl"}
 

--- a/cli/hq.py
+++ b/cli/hq.py
@@ -8,8 +8,6 @@ import os
 import sys
 from typing import Any, List, Optional, Tuple
 
-from hcl2.version import __version__
-
 from hcl2.query._base import NodeView
 from hcl2.query.body import DocumentView
 from hcl2.query.introspect import build_schema, describe_results
@@ -22,6 +20,7 @@ from hcl2.query.safe_eval import (
     safe_eval,
 )
 from hcl2.utils import SerializationOptions
+from hcl2.version import __version__
 
 from .helpers import _expand_file_args  # noqa: F401 — re-exported for tests
 

--- a/cli/json_to_hcl.py
+++ b/cli/json_to_hcl.py
@@ -8,8 +8,6 @@ import sys
 from io import StringIO
 from typing import TextIO
 
-from hcl2.version import __version__
-
 import hcl2
 from cli.helpers import (
     EXIT_DIFF,
@@ -29,6 +27,7 @@ from hcl2.deserializer import DeserializerOptions
 from hcl2.formatter import FormatterOptions
 from hcl2.query.diff import diff_dicts, format_diff_json, format_diff_text
 from hcl2.utils import SerializationOptions
+from hcl2.version import __version__
 
 
 def _json_to_hcl(


### PR DESCRIPTION
## Why

`pre-commit run --all-files` currently fails `ruff check` on `main`. Four files place `from hcl2.version import __version__` ahead of the rest of the first-party import block, violating the `I` rule selected in `pyproject.toml`.

A repo whose lint sweep is red by default makes it hard to tell a new failure from the background noise — this came up while landing the current batch of fix PRs.

## What

Import order only, applied by `ruff check --fix`. No behaviour change.

```
bin/terraform_test | 3 +--
cli/hcl_to_json.py | 3 +--
cli/hq.py          | 3 +--
cli/json_to_hcl.py | 3 +--
```

## Not a defect

`don't commit to branch` also fails during `--all-files` when main is the checked-out branch. That hook exists to block commits to main, so failing there is intended. Only `ruff check` was a real problem.

## Test plan

- `pre-commit run --all-files`: ruff check, ruff format and mypy all pass after the change
- Full suite: 1470 tests, all passing