### PR TITLE
fix: parse heredocs with a single-character delimiter (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Restore `py.typed` marker so type checkers recognize `hcl2` (and `cli`) as typed packages. ([#298](https://github.com/amplify-education/python-hcl2/issues/298))
+- Parse heredocs whose delimiter is a single character, such as `<<E`. The spec defines the delimiter as an Identifier, which permits one character. ([#314](https://github.com/amplify-education/python-hcl2/issues/314))
 - Parse heredocs with an empty body again. A marker immediately followed by its closing delimiter failed to match, and the lexer then ran on to a later delimiter, silently absorbing the attributes in between. ([#309](https://github.com/amplify-education/python-hcl2/issues/309))
 - Negative integer literals load as numbers again instead of `${-N}` expression strings, matching negative floats and the pre-8.x behaviour. ([#307](https://github.com/amplify-education/python-hcl2/issues/307))
 - `strip_string_quotes` no longer unquotes string literals nested inside expressions, which produced invalid HCL such as `${upper(x)}` from `upper("x")`. ([#310](https://github.com/amplify-education/python-hcl2/issues/310))

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -86,9 +86,11 @@ COLONS: "::"
 // it applies between tokens, never inside a terminal's own pattern, so without
 // this a heredoc in a CRLF file fails to match at all. The body group is lazy
 // and optional so an empty body matches without the delimiter search running on
-// to a later marker.
-HEREDOC_TEMPLATE : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]+)\r?\n(?:(?:.|\n)*?\r?\n)??\s*(?P=heredoc)\r?\n/
-HEREDOC_TEMPLATE_TRIM : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]+)\r?\n(?:(?:.|\n)*?\r?\n)??\s*(?P=heredoc_trim)\r?\n/
+// to a later marker. The delimiter itself is `[a-zA-Z][a-zA-Z0-9._-]*` — the
+// trailing `*` rather than `+` because the spec's Identifier permits a single
+// character, so `<<E` is valid.
+HEREDOC_TEMPLATE : /<<(?P<heredoc>[a-zA-Z][a-zA-Z0-9._-]*)\r?\n(?:(?:.|\n)*?\r?\n)??\s*(?P=heredoc)\r?\n/
+HEREDOC_TEMPLATE_TRIM : /<<-(?P<heredoc_trim>[a-zA-Z][a-zA-Z0-9._-]*)\r?\n(?:(?:.|\n)*?\r?\n)??\s*(?P=heredoc_trim)\r?\n/
 
 // Ignore whitespace (but not newlines, as they're significant in HCL).
 // \r is ignored too so CRLF line endings (\r\n) parse the same as LF: the

--- a/hcl2/utils.py
+++ b/hcl2/utils.py
@@ -5,11 +5,13 @@ from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from typing import Optional, Tuple
 
-# \r? mirrors the heredoc terminals in hcl2.lark: these run against a token the
-# grammar already accepted, so failing to match a CRLF heredoc here would raise
-# on input that parsed cleanly.
-HEREDOC_PATTERN = re.compile(r"<<([a-zA-Z][a-zA-Z0-9._-]+)\r?\n([\s\S]*)\1", re.S)
-HEREDOC_TRIM_PATTERN = re.compile(r"<<-([a-zA-Z][a-zA-Z0-9._-]+)\r?\n([\s\S]*)\1", re.S)
+# These mirror the heredoc terminals in hcl2.lark and must track them. They run
+# against a token the grammar has already accepted, so any delimiter or line
+# ending the grammar admits but these reject raises RuntimeError on input that
+# parsed cleanly: hence `\r?` for CRLF, and `*` rather than `+` so a
+# single-character delimiter is matched here too.
+HEREDOC_PATTERN = re.compile(r"<<([a-zA-Z][a-zA-Z0-9._-]*)\r?\n([\s\S]*)\1", re.S)
+HEREDOC_TRIM_PATTERN = re.compile(r"<<-([a-zA-Z][a-zA-Z0-9._-]*)\r?\n([\s\S]*)\1", re.S)
 
 
 @dataclass

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -534,3 +534,36 @@ class TestStripStringQuotes(TestCase):
     def test_default_options_still_preserve_source_form(self):
         """Without the option, the source form is kept for reconstruction."""
         self.assertEqual(loads(r'a = "line1\nline2"' + "\n"), {"a": r'"line1\nline2"'})
+
+
+class TestSingleCharacterHeredocDelimiter(TestCase):
+    """`<<E` is a valid heredoc; the delimiter may be one character.
+
+    The spec defines the delimiter as an Identifier — `ID_Start (ID_Continue |
+    '-')*` — whose trailing `*` permits a single character. The grammar used
+    `+`, which required a second one, so `<<E` fell through to STRING_CHARS and
+    the parse failed.
+    """
+
+    def test_single_character_delimiter(self):
+        self.assertEqual(loads("a = <<E\nx\nE\n"), {"a": '"<<E\nx\nE"'})
+
+    def test_single_character_delimiter_trimmed(self):
+        self.assertEqual(loads("a = <<-E\n  x\n  E\n"), {"a": '"<<-E\n  x\n  E"'})
+
+    def test_single_character_delimiter_empty_body(self):
+        self.assertEqual(loads("a = <<E\nE\n"), {"a": '"<<E\nE"'})
+
+    def test_single_character_delimiter_flattens(self):
+        options = SerializationOptions(preserve_heredocs=False)
+        self.assertEqual(loads("a = <<E\nx\nE\n", serialization_options=options), {"a": '"x"'})
+
+    def test_single_character_delimiter_does_not_swallow_what_follows(self):
+        self.assertEqual(loads("a = <<E\nx\nE\nb = 1\n"), {"a": '"<<E\nx\nE"', "b": 1})
+
+    def test_body_line_ending_in_the_delimiter_still_safe(self):
+        """A one-character delimiter makes an accidental match likelier."""
+        self.assertEqual(loads("a = <<E\nsayE\nE\n"), {"a": '"<<E\nsayE\nE"'})
+
+    def test_multi_character_delimiter_unaffected(self):
+        self.assertEqual(loads("a = <<EOF\nx\nEOF\n"), {"a": '"<<EOF\nx\nEOF"'})


### PR DESCRIPTION
caused by #314 

## Problem

`<<E` fails to parse while `<<EO` succeeds. The spec defines the delimiter as an `Identifier`:

```ebnf
heredocTemplate = (("<<" | "<<-") Identifier Newline ... Identifier Newline);
Identifier      = ID_Start (ID_Continue | '-')*;
```

The trailing `*` permits a single character. The grammar used `+`, requiring a second one, so `<<E` fell through to `STRING_CHARS`.

Long-standing rather than a v8 regression — the same pattern is present pre-8.x.

## The fix is in two places, not one

Relaxing `+` → `*` in `hcl2.lark` makes `<<E` parse, and the full suite stayed green. That was misleading: `hcl2/utils.py` carries a **duplicate** of the delimiter regex in `HEREDOC_PATTERN` / `HEREDOC_TRIM_PATTERN`, which re-match a token the grammar has already accepted. With only the grammar relaxed:

```python
hcl2.loads("a = <<E\nx\nE\n", serialization_options=SerializationOptions(preserve_heredocs=False))
# RuntimeError: Invalid Heredoc token: <<E\nx\nE
```

The grammar accepted it and the serializer then rejected it. Nothing in the existing suite flattens a single-character heredoc, so this only surfaced because the new tests cover the flatten path. Both sites now carry a comment noting they must track each other — this is the third time they have drifted (see also the CRLF work in #317).

## Tests

`TestSingleCharacterHeredocDelimiter` — plain and trimmed forms, empty body, flattening, an attribute after the heredoc, and a body line ending in the delimiter (`sayE` / `E`), which matters more at one character since an accidental match is likelier. A multi-character control confirms nothing shifted.

Without the grammar change, 6 of the 7 fail.

## Test plan

- Full suite: **1511 passing** (baseline 1504)
- `pre-commit run`: clean
- No lexing ambiguity observed; `STRING_CHARS` and the operator terminals are unaffected

## Scope: the character class is deliberately untouched

This PR changes the delimiter's **length** rule (`+` → `*`), not its character class. Worth being explicit, because the spec argument above would also implicate the class, and it does not line up with the grammar's own identifier terminal in either direction:

| Delimiter | Heredoc | Valid identifier (`NAME`) |
|---|---|---|
| `_EOF` | rejected | accepted |
| `EO.F` | accepted | rejected |
| `EO_F`, `EO-F`, `E1` | accepted | accepted |
| `1E` | rejected | rejected |

`NAME` is `[a-zA-Z_][a-zA-Z0-9_-]*`; the heredoc delimiter is `[a-zA-Z][a-zA-Z0-9._-]*`. So a leading underscore is a valid identifier but not a valid delimiter, and a dot is a valid delimiter but not a valid identifier.

Left alone on purpose: #314 is specifically about length, nobody has reported the class, and changing it would widen what the lexer accepts on a path that has already needed three corrections this cycle. Filing it separately if we want it.

## Test scope

Unit tests only, no integration fixture — the same call made for the empty-heredoc fix in #312. The behaviour is a lexer-level accept/reject plus one flatten path, both of which unit tests cover directly; a golden fixture would add four files without adding signal.
