### PR TITLE
fix: allow keywords as block type names and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## \[Unreleased\]
 
-- Nothing yet.
+### Fixed
+
+- Parse keywords as block types and block labels, not only as attribute names. `in { ... }`, `for { ... }`, `for_each { ... }`, and `resource in { ... }` all failed to parse even though the matching attribute form `in = 1` worked. Keywords are reserved only inside expressions; in a body they are ordinary names. ([#355](https://github.com/amplify-education/python-hcl2/pull/355))
 
 ## \[8.1.3\] - 2026-08-26
 

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -113,7 +113,7 @@ start : body
 body : (new_line_or_comment? (attribute | block))* new_line_or_comment?
 attribute : _attribute_name EQ expression
 _attribute_name : identifier | keyword | literal_value
-block : identifier (identifier | string)* new_line_or_comment? LBRACE body RBRACE
+block : _attribute_name (_attribute_name | string)* new_line_or_comment? LBRACE body RBRACE
 
 // Whitespace and comments
 new_line_or_comment: ( NL_OR_COMMENT )+

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -130,6 +130,14 @@ class RuleTransformer(Transformer):
 
     @v_args(meta=True)
     def block(self, meta: Meta, args) -> BlockRule:
+        # _attribute_name is flattened, so the block type and bare labels may be
+        # KeywordRule or LiteralValueRule; normalize so labels are all one type.
+        args = [
+            IdentifierRule([NAME(a.token.value)], meta)
+            if isinstance(a, (KeywordRule, LiteralValueRule))
+            else a
+            for a in args
+        ]
         return BlockRule(args, meta)
 
     @v_args(meta=True)

--- a/test/integration/hcl2_original/resource_keyword_block.tf
+++ b/test/integration/hcl2_original/resource_keyword_block.tf
@@ -1,0 +1,31 @@
+resource "custom_provider_resource" "resource_name" {
+  name = "resource_name"
+
+  if {
+    value = "block_value1"
+  }
+
+  in {
+    value = "block_value2"
+  }
+
+  for {
+    value = "block_value3"
+  }
+
+  for_each {
+    value = "block_value4"
+  }
+
+  true {
+    value = "block_value5"
+  }
+}
+
+in "labeled_block" {
+  value = "top_level_value"
+}
+
+resource in {
+  value = "keyword_label_value"
+}

--- a/test/integration/hcl2_reconstructed/resource_keyword_block.tf
+++ b/test/integration/hcl2_reconstructed/resource_keyword_block.tf
@@ -1,0 +1,37 @@
+resource "custom_provider_resource" "resource_name" {
+  name = "resource_name"
+  
+  if {
+    value = "block_value1"
+  }
+  
+
+  in {
+    value = "block_value2"
+  }
+  
+
+  for {
+    value = "block_value3"
+  }
+  
+
+  for_each {
+    value = "block_value4"
+  }
+  
+
+  true {
+    value = "block_value5"
+  }
+}
+
+
+resource in {
+  value = "keyword_label_value"
+}
+
+
+in "labeled_block" {
+  value = "top_level_value"
+}

--- a/test/integration/json_reserialized/resource_keyword_block.json
+++ b/test/integration/json_reserialized/resource_keyword_block.json
@@ -1,0 +1,56 @@
+{
+  "resource": [
+    {
+      "\"custom_provider_resource\"": {
+        "\"resource_name\"": {
+          "name": "\"resource_name\"",
+          "if": [
+            {
+              "value": "\"block_value1\"",
+              "__is_block__": true
+            }
+          ],
+          "in": [
+            {
+              "value": "\"block_value2\"",
+              "__is_block__": true
+            }
+          ],
+          "for": [
+            {
+              "value": "\"block_value3\"",
+              "__is_block__": true
+            }
+          ],
+          "for_each": [
+            {
+              "value": "\"block_value4\"",
+              "__is_block__": true
+            }
+          ],
+          "true": [
+            {
+              "value": "\"block_value5\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    },
+    {
+      "in": {
+        "value": "\"keyword_label_value\"",
+        "__is_block__": true
+      }
+    }
+  ],
+  "in": [
+    {
+      "\"labeled_block\"": {
+        "value": "\"top_level_value\"",
+        "__is_block__": true
+      }
+    }
+  ]
+}

--- a/test/integration/json_serialized/resource_keyword_block.json
+++ b/test/integration/json_serialized/resource_keyword_block.json
@@ -1,0 +1,56 @@
+{
+  "resource": [
+    {
+      "\"custom_provider_resource\"": {
+        "\"resource_name\"": {
+          "name": "\"resource_name\"",
+          "if": [
+            {
+              "value": "\"block_value1\"",
+              "__is_block__": true
+            }
+          ],
+          "in": [
+            {
+              "value": "\"block_value2\"",
+              "__is_block__": true
+            }
+          ],
+          "for": [
+            {
+              "value": "\"block_value3\"",
+              "__is_block__": true
+            }
+          ],
+          "for_each": [
+            {
+              "value": "\"block_value4\"",
+              "__is_block__": true
+            }
+          ],
+          "true": [
+            {
+              "value": "\"block_value5\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    },
+    {
+      "in": {
+        "value": "\"keyword_label_value\"",
+        "__is_block__": true
+      }
+    }
+  ],
+  "in": [
+    {
+      "\"labeled_block\"": {
+        "value": "\"top_level_value\"",
+        "__is_block__": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Keywords parse as attribute names but not as block names:

```hcl
in = 1        # works today

in { }        # UnexpectedToken
for_each { }  # UnexpectedToken
resource in { }  # UnexpectedToken
```

Keywords (`in`, `for`, `if`, `for_each`, `else`, `endif`, `endfor`) and literal keywords (`true`, `false`, `null`) are reserved only *inside expressions*. In a body they are ordinary names, valid as a block type or label just as they already are as attribute names.

The grammar already encodes this for attributes and simply never carried it to blocks:

```lark
attribute : _attribute_name EQ expression
_attribute_name : identifier | keyword | literal_value   ← keywords allowed
block : identifier (identifier | string)* ...            ← but not here
```

This continues the line of #164 (attributes named `in`) and #168 (`if`/`for_each` as identifiers), which fixed the attribute side only.

## Fix

One line of grammar — reuse the existing `_attribute_name` rule in the block type and label positions:

```lark
block : _attribute_name (_attribute_name | string)* new_line_or_comment? LBRACE body RBRACE
```

No new rule, so nothing to keep in sync. Because the rule is inlined, `block()` now receives `KeywordRule`/`LiteralValueRule` for bare names, so the transformer normalizes them to `IdentifierRule` — exactly what `attribute()` already does — keeping `BlockRule.labels` a single type for downstream consumers.

## Testing

- New `resource_keyword_block` integration suite (the block-side sibling of the existing `resource_keyword_attribute`), covering keyword block types, a keyword label (`resource in`), nesting, and a string label. All four pipeline files included.
- Verified the fixture genuinely guards the fix: reverting the source with the fixture present produces 11 failures.
- Full suite green: **1518 tests, 0 failures**, unchanged from baseline.
- Expression keywords confirmed still reserved: for-tuple, for-object, conditional, `for_each =`, and template `%{ for }` / `%{ if }` directives all parse and reconstruct as before.
- `pre-commit` clean (ruff, ruff format, mypy).

## Note for reviewers

Sharing `_attribute_name` also permits `true { }` / `null { }` as block names. That matches HCL, where a block type is an Identifier and these are contextual keywords, and it matches how they are already accepted as attribute names. Easy to restrict to `identifier | keyword` at the block position if you would rather not accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)