### PR TITLE
fix: accept HCL keywords as block labels and object keys (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## \[Unreleased\]
 
-- Nothing yet.
+### Fixed
+
+- Parse blocks whose type or unquoted label is an HCL keyword, such as the `in` block of the Snowflake provider's `snowflake_schemas` data source. HCL does not reserve its keywords, so `if`, `in`, `for`, `for_each`, `else`, `endif`, `endfor`, `true`, `false`, and `null` are now accepted in every block label position and normalized to identifiers — matching the existing behaviour for keyword attribute names.
+- Parse keyword-named *object* keys reliably, fixing a regression of [#148](https://github.com/amplify-education/python-hcl2/issues/148). `object_elem_key` did not accept the keyword terminals, so a key such as `in` parsed only in states where the contextual lexer happened to fall back to `NAME` — which made the key's position inside the object decide whether the file parsed. `{ in = "header", name = "n" }` worked while `{ name = "n", in = "header" }` failed, so the `jsonencode` OpenAPI body from the original report still raised. Keys such as `for` failed in every position.
 
 ## \[8.1.3\] - 2026-08-26
 

--- a/hcl2/hcl2.lark
+++ b/hcl2/hcl2.lark
@@ -113,7 +113,11 @@ start : body
 body : (new_line_or_comment? (attribute | block))* new_line_or_comment?
 attribute : _attribute_name EQ expression
 _attribute_name : identifier | keyword | literal_value
-block : identifier (identifier | string)* new_line_or_comment? LBRACE body RBRACE
+// HCL does not reserve its keywords, so a block type or an unquoted label may
+// be spelled `in`, `for`, `true`, etc. (e.g. the `in` block in the Snowflake
+// provider). The transformer normalizes those back to identifiers.
+block : _block_label (_block_label | string)* new_line_or_comment? LBRACE body RBRACE
+_block_label : identifier | keyword | literal_value
 
 // Whitespace and comments
 new_line_or_comment: ( NL_OR_COMMENT )+
@@ -225,7 +229,13 @@ template_string : TEMPLATE_STRING
 tuple : LSQB new_line_or_comment? (expression new_line_or_comment? COMMA new_line_or_comment?)* (expression new_line_or_comment? COMMA? new_line_or_comment?)?  RSQB
 object : LBRACE new_line_or_comment? ((object_elem | (object_elem new_line_or_comment? COMMA)) new_line_or_comment?)* RBRACE
 object_elem : object_elem_key ( EQ | COLON ) expression
-object_elem_key : expression
+// `keyword` is listed explicitly because it is not reachable through
+// `expression`: `in`, `for`, etc. lex as their own terminals, never as NAME.
+// Without this, `{ type = "apiKey", in = "header" }` fails — the contextual
+// lexer only falls back to NAME in states that do not accept the keyword
+// terminal, which made the key's position in the object decide whether it
+// parsed. The transformer normalizes these to identifiers.
+object_elem_key : expression | keyword
 
 // Heredocs
 heredoc_template : HEREDOC_TEMPLATE

--- a/hcl2/transformer.py
+++ b/hcl2/transformer.py
@@ -130,6 +130,15 @@ class RuleTransformer(Transformer):
 
     @v_args(meta=True)
     def block(self, meta: Meta, args) -> BlockRule:
+        # _block_label is flattened, so a label may be a KeywordRule or a
+        # LiteralValueRule (HCL keywords are not reserved, so `in {}` is a
+        # legal block). Normalize them so labels are always identifiers.
+        args = [
+            IdentifierRule([NAME(arg.token.value)], meta)
+            if isinstance(arg, (KeywordRule, LiteralValueRule))
+            else arg
+            for arg in args
+        ]
         return BlockRule(args, meta)
 
     @v_args(meta=True)
@@ -331,6 +340,11 @@ class RuleTransformer(Transformer):
     @v_args(meta=True)
     def object_elem_key(self, meta: Meta, args):
         expr = args[0]
+        # A bare keyword key (`in = "header"`) arrives unwrapped, since
+        # `keyword` is its own alternative in the grammar rather than being
+        # reachable through `expression`. Treat it as an identifier key.
+        if isinstance(expr, KeywordRule):
+            return ObjectElemKeyRule([IdentifierRule([NAME(expr.token.value)], meta)], meta)
         # Simple literals (identifier, string, int, float) wrapped in ExprTermRule
         if isinstance(expr, ExprTermRule) and len(expr.children) == 5:
             inner = expr.children[2]  # position 2 in [None, None, inner, None, None]

--- a/test/integration/hcl2_original/object_keyword_keys.tf
+++ b/test/integration/hcl2_original/object_keyword_keys.tf
@@ -1,0 +1,32 @@
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    security_definitions = {
+      sigv4 = {
+        type                         = "apiKey"
+        name                         = "Authorization"
+        in                           = "header"
+        x-amazon-apigateway-authtype = "awsSigv4"
+      }
+    }
+  })
+}
+
+keywords_in_every_position = {
+  leading  = 0
+  if       = 1
+  in       = 2
+  for      = 3
+  for_each = 4
+  else     = 5
+  endif    = 6
+  endfor   = 7
+  true     = 8
+  false    = 9
+  null     = 10
+  trailing = 11
+}
+
+colon_separated = {
+  a : 0,
+  in : "header"
+}

--- a/test/integration/hcl2_original/resource_keyword_block.tf
+++ b/test/integration/hcl2_original/resource_keyword_block.tf
@@ -1,0 +1,43 @@
+data "snowflake_schemas" "in" {
+  in {
+    database = "database"
+  }
+}
+
+resource "custom_provider_resource" "resource_name" {
+  if {
+    name = "if_block"
+  }
+  for {
+    name = "for_block"
+  }
+  for_each {
+    name = "for_each_block"
+  }
+  else {
+    name = "else_block"
+  }
+  endif {
+    name = "endif_block"
+  }
+  endfor {
+    name = "endfor_block"
+  }
+  true {
+    name = "true_block"
+  }
+  false {
+    name = "false_block"
+  }
+  null {
+    name = "null_block"
+  }
+}
+
+in "quoted_label" {
+  attribute = "value"
+}
+
+block in {
+  attribute = "value"
+}

--- a/test/integration/hcl2_reconstructed/object_keyword_keys.tf
+++ b/test/integration/hcl2_reconstructed/object_keyword_keys.tf
@@ -1,0 +1,31 @@
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    security_definitions = {
+      sigv4 = {
+        type                         = "apiKey",
+        name                         = "Authorization",
+        in                           = "header",
+        x-amazon-apigateway-authtype = "awsSigv4"
+      }
+    }
+  })
+}
+
+keywords_in_every_position = {
+  leading  = 0,
+  if       = 1,
+  in       = 2,
+  for      = 3,
+  for_each = 4,
+  else     = 5,
+  endif    = 6,
+  endfor   = 7,
+  true     = 8,
+  false    = 9,
+  null     = 10,
+  trailing = 11,
+}
+colon_separated = {
+  a  = 0,
+  in = "header",
+}

--- a/test/integration/hcl2_reconstructed/resource_keyword_block.tf
+++ b/test/integration/hcl2_reconstructed/resource_keyword_block.tf
@@ -1,0 +1,62 @@
+data "snowflake_schemas" "in" {
+  in {
+    database = "database"
+  }
+}
+
+
+resource "custom_provider_resource" "resource_name" {
+  if {
+    name = "if_block"
+  }
+  
+
+  for {
+    name = "for_block"
+  }
+  
+
+  for_each {
+    name = "for_each_block"
+  }
+  
+
+  else {
+    name = "else_block"
+  }
+  
+
+  endif {
+    name = "endif_block"
+  }
+  
+
+  endfor {
+    name = "endfor_block"
+  }
+  
+
+  true {
+    name = "true_block"
+  }
+  
+
+  false {
+    name = "false_block"
+  }
+  
+
+  null {
+    name = "null_block"
+  }
+}
+
+
+in "quoted_label" {
+  attribute = "value"
+}
+
+
+block in {
+  attribute = "value"
+}

--- a/test/integration/json_reserialized/object_keyword_keys.json
+++ b/test/integration/json_reserialized/object_keyword_keys.json
@@ -1,0 +1,30 @@
+{
+  "resource": [
+    {
+      "\"aws_api_gateway_rest_api\"": {
+        "\"example\"": {
+          "body": "${jsonencode({security_definitions = {sigv4 = {type = \"apiKey\", name = \"Authorization\", in = \"header\", x-amazon-apigateway-authtype = \"awsSigv4\"}}})}",
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "keywords_in_every_position": {
+    "leading": 0,
+    "if": 1,
+    "in": 2,
+    "for": 3,
+    "for_each": 4,
+    "else": 5,
+    "endif": 6,
+    "endfor": 7,
+    "true": 8,
+    "false": 9,
+    "null": 10,
+    "trailing": 11
+  },
+  "colon_separated": {
+    "a": 0,
+    "in": "\"header\""
+  }
+}

--- a/test/integration/json_reserialized/resource_keyword_block.json
+++ b/test/integration/json_reserialized/resource_keyword_block.json
@@ -1,0 +1,96 @@
+{
+  "data": [
+    {
+      "\"snowflake_schemas\"": {
+        "\"in\"": {
+          "in": [
+            {
+              "database": "\"database\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "resource": [
+    {
+      "\"custom_provider_resource\"": {
+        "\"resource_name\"": {
+          "if": [
+            {
+              "name": "\"if_block\"",
+              "__is_block__": true
+            }
+          ],
+          "for": [
+            {
+              "name": "\"for_block\"",
+              "__is_block__": true
+            }
+          ],
+          "for_each": [
+            {
+              "name": "\"for_each_block\"",
+              "__is_block__": true
+            }
+          ],
+          "else": [
+            {
+              "name": "\"else_block\"",
+              "__is_block__": true
+            }
+          ],
+          "endif": [
+            {
+              "name": "\"endif_block\"",
+              "__is_block__": true
+            }
+          ],
+          "endfor": [
+            {
+              "name": "\"endfor_block\"",
+              "__is_block__": true
+            }
+          ],
+          "true": [
+            {
+              "name": "\"true_block\"",
+              "__is_block__": true
+            }
+          ],
+          "false": [
+            {
+              "name": "\"false_block\"",
+              "__is_block__": true
+            }
+          ],
+          "null": [
+            {
+              "name": "\"null_block\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "in": [
+    {
+      "\"quoted_label\"": {
+        "attribute": "\"value\"",
+        "__is_block__": true
+      }
+    }
+  ],
+  "block": [
+    {
+      "in": {
+        "attribute": "\"value\"",
+        "__is_block__": true
+      }
+    }
+  ]
+}

--- a/test/integration/json_serialized/object_keyword_keys.json
+++ b/test/integration/json_serialized/object_keyword_keys.json
@@ -1,0 +1,30 @@
+{
+  "resource": [
+    {
+      "\"aws_api_gateway_rest_api\"": {
+        "\"example\"": {
+          "body": "${jsonencode({security_definitions = {sigv4 = {type = \"apiKey\", name = \"Authorization\", in = \"header\", x-amazon-apigateway-authtype = \"awsSigv4\"}}})}",
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "keywords_in_every_position": {
+    "leading": 0,
+    "if": 1,
+    "in": 2,
+    "for": 3,
+    "for_each": 4,
+    "else": 5,
+    "endif": 6,
+    "endfor": 7,
+    "true": 8,
+    "false": 9,
+    "null": 10,
+    "trailing": 11
+  },
+  "colon_separated": {
+    "a": 0,
+    "in": "\"header\""
+  }
+}

--- a/test/integration/json_serialized/resource_keyword_block.json
+++ b/test/integration/json_serialized/resource_keyword_block.json
@@ -1,0 +1,96 @@
+{
+  "data": [
+    {
+      "\"snowflake_schemas\"": {
+        "\"in\"": {
+          "in": [
+            {
+              "database": "\"database\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "resource": [
+    {
+      "\"custom_provider_resource\"": {
+        "\"resource_name\"": {
+          "if": [
+            {
+              "name": "\"if_block\"",
+              "__is_block__": true
+            }
+          ],
+          "for": [
+            {
+              "name": "\"for_block\"",
+              "__is_block__": true
+            }
+          ],
+          "for_each": [
+            {
+              "name": "\"for_each_block\"",
+              "__is_block__": true
+            }
+          ],
+          "else": [
+            {
+              "name": "\"else_block\"",
+              "__is_block__": true
+            }
+          ],
+          "endif": [
+            {
+              "name": "\"endif_block\"",
+              "__is_block__": true
+            }
+          ],
+          "endfor": [
+            {
+              "name": "\"endfor_block\"",
+              "__is_block__": true
+            }
+          ],
+          "true": [
+            {
+              "name": "\"true_block\"",
+              "__is_block__": true
+            }
+          ],
+          "false": [
+            {
+              "name": "\"false_block\"",
+              "__is_block__": true
+            }
+          ],
+          "null": [
+            {
+              "name": "\"null_block\"",
+              "__is_block__": true
+            }
+          ],
+          "__is_block__": true
+        }
+      }
+    }
+  ],
+  "in": [
+    {
+      "\"quoted_label\"": {
+        "attribute": "\"value\"",
+        "__is_block__": true
+      }
+    }
+  ],
+  "block": [
+    {
+      "in": {
+        "attribute": "\"value\"",
+        "__is_block__": true
+      }
+    }
+  ]
+}

--- a/test/unit/test_api.py
+++ b/test/unit/test_api.py
@@ -20,6 +20,7 @@ from hcl2.api import (
     serialize,
     transform,
 )
+from hcl2.const import IS_BLOCK
 from hcl2.deserializer import DeserializerOptions
 from hcl2.formatter import FormatterOptions
 from hcl2.rules.base import StartRule
@@ -446,6 +447,137 @@ class TestNegatedKeywords(TestCase):
     def test_bare_keywords_are_still_python_values(self):
         """Outside an expression the keywords keep their Python mappings."""
         self.assertEqual(loads("x = true\ny = false\nz = null\n"), {"x": True, "y": False, "z": None})
+
+
+class TestKeywordBlocks(TestCase):
+    """HCL does not reserve its keywords, so `in {}` is a legal block.
+
+    The Snowflake provider's `snowflake_schemas` data source nests an `in`
+    block, and keyword-named block types used to fail to lex because `in`
+    only ever produced the `IN` terminal. Keywords are accepted in every
+    label position and normalized to identifiers, matching the long-standing
+    behaviour for keyword *attribute* names.
+    """
+
+    def test_in_block(self):
+        source = 'data "snowflake_schemas" "in" {\n  in {\n    database = "database"\n  }\n}\n'
+        inner = {"database": '"database"', IS_BLOCK: True}
+        self.assertEqual(
+            loads(source),
+            {"data": [{'"snowflake_schemas"': {'"in"': {"in": [inner], IS_BLOCK: True}}}]},
+        )
+
+    def test_every_keyword_is_a_valid_block_type(self):
+        for keyword in ("if", "in", "for", "for_each", "else", "endif", "endfor", "true", "false", "null"):
+            with self.subTest(keyword=keyword):
+                self.assertEqual(loads(f"{keyword} {{\n  a = 1\n}}\n"), {keyword: [{"a": 1, IS_BLOCK: True}]})
+
+    def test_keyword_as_quoted_and_unquoted_label(self):
+        self.assertEqual(loads('block "in" {\n  a = 1\n}\n'), {"block": [{'"in"': {"a": 1, IS_BLOCK: True}}]})
+        self.assertEqual(loads("block in {\n  a = 1\n}\n"), {"block": [{"in": {"a": 1, IS_BLOCK: True}}]})
+
+    def test_keyword_block_survives_the_direct_pipeline(self):
+        source = "in {\n  for = 1\n}\n"
+        self.assertEqual(reconstruct(parses(source).to_lark()), source)
+
+    def test_keyword_block_survives_the_dict_pipeline(self):
+        self.assertEqual(loads(dumps(loads("in {\n  a = 1\n}\n"))), {"in": [{"a": 1, IS_BLOCK: True}]})
+
+    def test_keyword_labels_are_normalized_to_identifiers(self):
+        """A `true` label must read back as the string "true", not Python `True`."""
+        block = query("true in {\n  a = 1\n}\n").blocks()[0]
+        self.assertEqual(block.block_type, "true")
+        self.assertEqual(block.labels, ["true", "in"])
+
+    def test_expression_keywords_still_parse(self):
+        """Accepting keyword labels must not break `for`/`if`/`in` in expressions."""
+        self.assertEqual(
+            loads("x = [for i in [1, 2] : i if i > 1]\n"), {"x": "${[for i in [1, 2] : i if i > 1]}"}
+        )
+
+
+class TestKeywordAttributeNames(TestCase):
+    """`in` as an attribute name — issue #148, fixed by PR #164.
+
+    The report is an OpenAPI body built with `jsonencode`, where `in` names
+    an *object element*. That is a different grammar path from a block-body
+    attribute (`object_elem_key` vs `_attribute_name`), and only the latter
+    got a regression test in #164. The object path then worked by accident:
+    the contextual lexer falls back to NAME only in states that do not accept
+    the `IN` terminal, so whether the key parsed depended on its position in
+    the object.
+    """
+
+    # https://github.com/amplify-education/python-hcl2/issues/148
+    # The report's own snippet, with its tab indentation normalized to spaces
+    # (whitespace is ignored here and mixing tabs into the source trips ruff).
+    ISSUE_148_SOURCE = """resource "aws_api_gateway_rest_api" "example" {
+
+  body = jsonencode({
+    security_definitions = {
+      sigv4 = {
+        type                         = "apiKey"
+        name                         = "Authorization"
+        in                           = "header"
+        x-amazon-apigateway-authtype = "awsSigv4"
+      }
+    }
+  })
+}
+"""
+
+    def test_issue_148_report(self):
+        body = loads(self.ISSUE_148_SOURCE)["resource"][0]['"aws_api_gateway_rest_api"']['"example"']
+        self.assertIn('in = "header"', body["body"])
+
+    def test_issue_148_report_with_tab_indentation(self):
+        """The report used tabs; whitespace must not matter."""
+        source = self.ISSUE_148_SOURCE.replace("    ", "\t")
+        body = loads(source)["resource"][0]['"aws_api_gateway_rest_api"']['"example"']
+        self.assertIn('in = "header"', body["body"])
+
+    def test_in_key_in_any_position(self):
+        """Position in the object must not decide whether the key parses."""
+        self.assertEqual(loads('x = {\n  in = "h"\n  name = "n"\n}\n'), {"x": {"in": '"h"', "name": '"n"'}})
+        self.assertEqual(loads('x = {\n  name = "n"\n  in = "h"\n}\n'), {"x": {"name": '"n"', "in": '"h"'}})
+
+    def test_every_keyword_is_a_valid_object_key(self):
+        for keyword in ("if", "in", "for", "for_each", "else", "endif", "endfor", "true", "false", "null"):
+            with self.subTest(keyword=keyword):
+                self.assertEqual(
+                    loads(f"x = {{\n  a = 0\n  {keyword} = 1\n}}\n"), {"x": {"a": 0, keyword: 1}}
+                )
+
+    def test_keyword_object_key_with_colon_separator(self):
+        self.assertEqual(loads('x = {\n  a : 0\n  in : "h"\n}\n'), {"x": {"a": 0, "in": '"h"'}})
+
+    # https://github.com/amplify-education/python-hcl2/pull/164
+    def test_pr_164_fixture(self):
+        source = (
+            'resource "custom_provider_resource" "resource_name" {\n'
+            '  name      = "resource_name"\n'
+            '  attribute = "attribute_value"\n'
+            '  in        = "attribute_value2"\n'
+            "}\n"
+        )
+        body = loads(source)["resource"][0]['"custom_provider_resource"']['"resource_name"']
+        self.assertEqual(body["in"], '"attribute_value2"')
+
+    def test_keyword_object_key_survives_the_direct_pipeline(self):
+        source = 'x = {\n  name = "n"\n  in   = "h"\n}\n'
+        self.assertEqual(reconstruct(parses(source).to_lark()), source)
+
+    def test_keyword_object_key_survives_the_dict_pipeline(self):
+        original = loads('x = {\n  name = "n"\n  in = "h"\n}\n')
+        self.assertEqual(loads(dumps(original)), original)
+
+    def test_for_expression_in_is_not_shadowed(self):
+        """`in` as an object key must not break `in` as the for-expression keyword."""
+        self.assertEqual(loads("x = {in = [for i in y : i]}\n"), {"x": {"in": "${[for i in y : i]}"}})
+        self.assertEqual(
+            loads("x = {for k, v in var.m : k => {in = v}}\n"),
+            {"x": "${{for k, v in var.m : k => {in = v}}}"},
+        )
 
 
 class TestStripStringQuotes(TestCase):


### PR DESCRIPTION
## Problem

HCL does not reserve its keywords, so `in`, `for`, `true`, etc. are legal identifiers. Two positions in the grammar rejected them.

### 1. Block labels

`block : identifier (identifier | string)* ...` where `identifier : NAME`, but `in` lexes as the dedicated `IN` terminal and never as `NAME`. In a body position the contextual lexer therefore only accepted `IN` as the start of an *attribute*, so this [documented Snowflake provider data source](https://registry.terraform.io/providers/snowflakedb/snowflake/latest/docs/data-sources/schemas) failed to parse:

```hcl
data "snowflake_schemas" "in" {
  in {
    database = "database"
  }
}
```

```
lark.exceptions.UnexpectedToken: Unexpected token Token('IN', 'in')
Expected one of:
	* EQ
Previous tokens: [Token('IN', 'in')]
```

### 2. Object keys — a regression of #148

`object_elem_key : expression` cannot reach `keyword` either. #148 was fixed once by #164, then lost when 8.x moved keywords out of `identifier` into their own `keyword` rule and wired it only into `_attribute_name`.

#164's regression fixture covered a **block-body attribute**, which is a different grammar path (`_attribute_name`) from the **object element** (`object_elem_key`) that the issue actually reports. So the fixture kept passing while the reported case broke.

The object path then worked only by accident: Lark's contextual lexer falls back to `NAME` only in states that do not accept the keyword terminal, which made a key's **position in the object** decide whether the file parsed.

```hcl
{ in = "h", name = "n" }    # parsed
{ name = "n", in = "h" }    # failed  <- the shape in #148
{ for = 1 }                 # failed in every position
```

That second line is why the `jsonencode` OpenAPI body from #148 still raised on `main` — verified against a clean checkout, independent of this branch.

## Fix

| File | Change |
|---|---|
| `hcl2/hcl2.lark` | `block` labels route through a new `_block_label : identifier \| keyword \| literal_value`, mirroring `_attribute_name` |
| `hcl2/hcl2.lark` | `object_elem_key : expression \| keyword` |
| `hcl2/transformer.py` | `block()` and `object_elem_key()` normalize `KeywordRule` / `LiteralValueRule` to `IdentifierRule` |

LALR builds with no new conflicts: after reducing `keyword`, `EQ` still means attribute and `NAME`/`"`/`{` means block.

The normalization is load-bearing beyond tidiness. `_label_to_str` (`hcl2/query/blocks.py:14`) falls through to `str(label.serialize())`, and `LiteralValueRule` serializes `true` to Python `True` — so a `true`-named block would otherwise query as `"True"`.

## Testing

`unittest`: **1534 passing** (from 1518), on a freshly built grammar cache. ruff check, ruff format, and mypy pass.

**Unit** — `test/unit/test_api.py`:
- `TestKeywordBlocks` (8) — the Snowflake snippet, all ten keywords as block types, quoted and unquoted keyword labels, both reverse pipelines, and the `IdentifierRule` normalization via `query()`.
- `TestKeywordAttributeNames` (9) — #148's snippet with space **and** tab indentation, `in` in both object positions, all ten keywords as object keys, colon separator, #164's fixture, both reverse pipelines.

Both classes carry a guard that `in` still works as the for-expression keyword. Separately swept 14 for-expression and template-directive forms by hand — no regressions.

**Integration** — two new round-trip suites, `resource_keyword_block` and `object_keyword_keys`, each with all four golden files. Direct reconstruction (`HCL → IR → Lark → HCL`) is byte-identical to source for both.

## Notes for the reviewer

- `hq 'data.snowflake_schemas.in.in.database'` resolves correctly against the new fixture.
- One case is covered in unit tests rather than a golden-file suite: a for-expression used as a value reconstructs with a stray space (`[for i in x : i]` → `[ for i in x : i]`). That reproduces on clean `main` and is unrelated to keywords, so I left it alone rather than bake it into a golden file. Happy to fix it separately if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
