### PR TITLE
chore: prepare 8.1.4 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## \[Unreleased\]
 
+- Nothing yet.
+
+## \[8.1.4\] - 2026-09-08
+
 ### Fixed
 
-- Parse blocks whose type or unquoted label is an HCL keyword, such as the `in` block of the Snowflake provider's `snowflake_schemas` data source. HCL does not reserve its keywords, so `if`, `in`, `for`, `for_each`, `else`, `endif`, `endfor`, `true`, `false`, and `null` are now accepted in every block label position and normalized to identifiers — matching the existing behaviour for keyword attribute names. The block-side grammar gap was diagnosed independently in [#355](https://github.com/amplify-education/python-hcl2/pull/355). ([#357](https://github.com/amplify-education/python-hcl2/pull/357))
-- Parse keyword-named *object* keys reliably, fixing a regression of [#148](https://github.com/amplify-education/python-hcl2/issues/148). `object_elem_key` did not accept the keyword terminals, so a key such as `in` parsed only in states where the contextual lexer happened to fall back to `NAME` — which made the key's separator and position decide whether the file parsed. The comma-separated `{ name = "n", in = "header" }` parsed, but the newline-separated form the original report actually used did not, so its `jsonencode` OpenAPI body still raised. Keys such as `for` failed in every position. ([#357](https://github.com/amplify-education/python-hcl2/pull/357))
+- Parse blocks whose type or unquoted label is an HCL keyword, such as the `in` block in Snowflake's `snowflake_schemas` data source. HCL reserves no keywords, so all are now accepted as block labels. Diagnosed independently in [#355](https://github.com/amplify-education/python-hcl2/pull/355). ([#357](https://github.com/amplify-education/python-hcl2/pull/357))
+- Parse keyword-named *object* keys reliably, fixing a regression of [#148](https://github.com/amplify-education/python-hcl2/issues/148). A key such as `in` parsed only where the lexer fell back to `NAME`, so its separator and position decided whether the file parsed. ([#357](https://github.com/amplify-education/python-hcl2/pull/357))
 
 ## \[8.1.3\] - 2026-08-26
 


### PR DESCRIPTION
## Summary

Moves the two keyword-parsing fixes from #357 out of `[Unreleased]` into a dated `8.1.4` section so the release notes are ready to tag. This stays a patch release: both entries are bug fixes, with no API additions and no behaviour change for input that already parsed correctly.

## Changes

- Add `## [8.1.4] - 2026-09-08` containing the keyword block-label and keyword object-key fixes from #357.
- Reset `[Unreleased]` to the `- Nothing yet.` placeholder.
- Condense both entries to roughly two lines each, keeping the Snowflake `snowflake_schemas` example, the #148 regression reference, and the #355 credit.

## Manual testing checklist

- [x] Render `CHANGELOG.md` and confirm the `8.1.4` section sits between `[Unreleased]` and `8.1.3`, dated `2026-09-08`.
- [x] Confirm the `#148`, `#355`, and `#357` links resolve to the right issue/PRs.
- [x] Confirm no already-released section changed — the diff against `main` should touch only the top of the file.

Documentation-only change; the pre-commit markdown, trailing-whitespace, and end-of-file hooks pass on `CHANGELOG.md`.

Relates to #357

---

🤖 Co-Authored-By: Claude Opus 5 (1M context) [Claude Code](https://claude.com/claude-code)
